### PR TITLE
improve printing date values

### DIFF
--- a/meteor-app/imports/utility/printable.test.ts
+++ b/meteor-app/imports/utility/printable.test.ts
@@ -14,6 +14,10 @@ describe('printable', function () {
         assert.deepStrictEqual(printable(null), '[null]');
     });
 
+    it('returns correct string for Dates', async function () {
+        assert.deepStrictEqual(printable(new Date('2023-08-06T04:32:37.448Z')), '[date]2023-08-06T04:32:37.448Z');
+    });
+
     it('flattens complex values into a shallow object', async function () {
         assert.deepStrictEqual(printable([1, '2', true]), { '0': '[number]1', '1': '[string]2', '2': '[boolean]true' });
         assert.deepStrictEqual(printable([[1, '2', true]]), {

--- a/meteor-app/imports/utility/printable.ts
+++ b/meteor-app/imports/utility/printable.ts
@@ -50,8 +50,8 @@ function printableRecursionHelper(path: Path, x: unknown): Array<{ path: Path; v
         return [
             {
                 path,
-                value: `[date]${x.toISOString()}`
-            }
+                value: `[date]${x.toISOString()}`,
+            },
         ];
     }
 

--- a/meteor-app/imports/utility/printable.ts
+++ b/meteor-app/imports/utility/printable.ts
@@ -7,11 +7,6 @@ function isPrintablePrimitive(x: unknown): x is PrintablePrimitive {
     return primitiveTypes.has(typeof x);
 }
 
-const printableObjectTypes: Array<(x: unknown) => boolean> = [(x) => x === null, (x) => x instanceof Date];
-function isPrintableObject(x: unknown): x is PrintableObject {
-    return printableObjectTypes.some((predicate) => predicate(x));
-}
-
 type Path = string[];
 
 function printableRecursionHelper(path: Path, x: unknown): Array<{ path: Path; value: Printable }> {
@@ -51,12 +46,12 @@ function printableRecursionHelper(path: Path, x: unknown): Array<{ path: Path; v
         ];
     }
 
-    if (isPrintableObject(x)) {
+    if (x instanceof Date) {
         return [
             {
                 path,
-                value: `[printable object]${String(x)}`,
-            },
+                value: `[date]${x.toISOString()}`
+            }
         ];
     }
 


### PR DESCRIPTION
Before: `[printable object]Sat Aug 05 2023 21:32:37 GMT-0700 (Pacific Daylight Time)`
After: `[date]2023-08-06T04:32:37.448Z`

It's a lot easier to read and copy/paste.