### PR TITLE
test: add SearchBar and TagSelector Storybook coverage (T016)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -41,7 +41,10 @@ jobs:
                   path: ~/.meteor
                   key: ${{ runner.os }}-meteor-${{ env.METEOR_VERSION }}
             - name: Install Meteor ${{ env.METEOR_VERSION }}
-              run: npm install -g meteor@${METEOR_VERSION}
+              run: |
+                  curl "https://install.meteor.com/?release=${METEOR_VERSION}" | sh
+                  echo "$HOME/.meteor" >> "$GITHUB_PATH"
+                  "$HOME/.meteor/meteor" --version
             - run: npm ci
             - run: meteor lint
             - run: npm run check:type
@@ -70,7 +73,10 @@ jobs:
                   path: ~/.meteor
                   key: ${{ runner.os }}-meteor-${{ env.METEOR_VERSION }}
             - name: Install Meteor ${{ env.METEOR_VERSION }}
-              run: npm install -g meteor@${METEOR_VERSION}
+              run: |
+                  curl "https://install.meteor.com/?release=${METEOR_VERSION}" | sh
+                  echo "$HOME/.meteor" >> "$GITHUB_PATH"
+                  "$HOME/.meteor/meteor" --version
             - run: npm ci
             - run: meteor lint
             - run: npm run check:code-style
@@ -99,7 +105,10 @@ jobs:
                   path: ~/.meteor
                   key: ${{ runner.os }}-meteor-${{ env.METEOR_VERSION }}
             - name: Install Meteor ${{ env.METEOR_VERSION }}
-              run: npm install -g meteor@${METEOR_VERSION}
+              run: |
+                  curl "https://install.meteor.com/?release=${METEOR_VERSION}" | sh
+                  echo "$HOME/.meteor" >> "$GITHUB_PATH"
+                  "$HOME/.meteor/meteor" --version
             - run: meteor npm ci
             - run: meteor npm run build --if-present
             - run: meteor npm test

--- a/meteor-app/imports/ui/SearchBar.stories.tsx
+++ b/meteor-app/imports/ui/SearchBar.stories.tsx
@@ -171,6 +171,43 @@ export const Interactive: Story = {
 };
 
 /**
+ * Deterministic test harness for Playwright component tests.
+ */
+export const TestInteractions: Story = {
+    render: () => {
+        const [query, setQuery] = useState('');
+        const [lastSearch, setLastSearch] = useState('');
+        const [searchCount, setSearchCount] = useState(0);
+        const [clearCount, setClearCount] = useState(0);
+
+        return (
+            <div style={{ maxWidth: '600px' }}>
+                <SearchBar
+                    value={query}
+                    searchMode="scoped"
+                    scopeLabel="In: Garage"
+                    onChange={setQuery}
+                    onSearch={(nextQuery) => {
+                        setLastSearch(nextQuery);
+                        setSearchCount((count) => count + 1);
+                    }}
+                    onClear={() => {
+                        setQuery('');
+                        setClearCount((count) => count + 1);
+                    }}
+                />
+                <div style={{ marginTop: '16px' }}>
+                    <div data-testid="current-query">{query || '(empty)'}</div>
+                    <div data-testid="last-search">{lastSearch || '(none)'}</div>
+                    <div data-testid="search-count">{searchCount}</div>
+                    <div data-testid="clear-count">{clearCount}</div>
+                </div>
+            </div>
+        );
+    },
+};
+
+/**
  * Long scope label to test text wrapping
  */
 export const LongScopeLabel: Story = {

--- a/meteor-app/imports/ui/TagSelector.stories.tsx
+++ b/meteor-app/imports/ui/TagSelector.stories.tsx
@@ -286,6 +286,44 @@ Click checkboxes to select/deselect tags in real-time. The selection count updat
     },
 };
 
+// Story: Deterministic test harness for Playwright component tests
+export const TestInteractions: Story = {
+    render: () => {
+        const testTags = sampleTags.slice(0, 3);
+        const [selectedTagIds, setSelectedTagIds] = useState<string[]>(['tag1']);
+        const [lastToggle, setLastToggle] = useState('');
+        const [createCount, setCreateCount] = useState(0);
+
+        const handleToggleTag = (tagId: string, isSelected: boolean): void => {
+            setSelectedTagIds((current) =>
+                isSelected ? [...current, tagId] : current.filter((selectedTagId) => selectedTagId !== tagId)
+            );
+            setLastToggle(`${tagId}:${isSelected}`);
+        };
+
+        return (
+            <Box gap="medium" width="medium">
+                <TagSelector
+                    availableTags={testTags}
+                    selectedTagIds={selectedTagIds}
+                    onToggleTag={handleToggleTag}
+                    onCreateNewTag={() => {
+                        setCreateCount((count) => count + 1);
+                    }}
+                />
+                <Box gap="small">
+                    <Text size="small" data-testid="last-toggle">
+                        {lastToggle || '(none)'}
+                    </Text>
+                    <Text size="small" data-testid="create-count">
+                        {createCount}
+                    </Text>
+                </Box>
+            </Box>
+        );
+    },
+};
+
 // Story: In a dialog context
 export const InDialogContext: Story = {
     render: () => (

--- a/meteor-app/imports/ui/TagSelector.tsx
+++ b/meteor-app/imports/ui/TagSelector.tsx
@@ -100,7 +100,15 @@ export const TagSelector: React.FC<TagSelectorProps> = ({
                             style={{ minHeight: '44px' }}
                         >
                             <CheckBox
-                                label={tag.name}
+                                label={
+                                    <Box
+                                        data-testid={`tag-touch-target-${tag._id}`}
+                                        justify="center"
+                                        style={{ minHeight: '44px' }}
+                                    >
+                                        <Text>{tag.name}</Text>
+                                    </Box>
+                                }
                                 checked={selectedTagIds.includes(tag._id)}
                                 onChange={(event) => {
                                     handleToggle(tag._id, event.target.checked);

--- a/specs/002-storybook-e2e-testing/plan.md
+++ b/specs/002-storybook-e2e-testing/plan.md
@@ -118,7 +118,7 @@ This feature establishes a two-phase E2E testing strategy to address the inabili
 
 **Current execution snapshot (2026-05-18)**:
 - Completed: Playwright Storybook project/config, shared Storybook helpers, context-agnostic page objects, ItemForm/TouchButton/CreateTagDialog/LongPressContextMenu/SearchBar/TagSelector test coverage, test pattern catalog, CI/CD guidance, and root-level npm scripts/README updates
-- Still open in `tasks.md`: touch-optimization refactor, quickstart refresh, and performance measurement
+- Still open in `tasks.md`: touch-optimization refactor and performance measurement
 
 **Next Action**: Keep `tasks.md` current as implementation continues; use `/speckit.analyze spec 002` or manual artifact updates to re-sync after major work lands outside the workflow
 
@@ -205,8 +205,7 @@ playwright.config.js              # Storybook + app projects with optional auto-
 
 **Remaining Critical Path**:
 1. Finish touch-optimization refactor (T012b)
-2. Refresh quickstart examples based on shipped patterns (T018)
-3. Measure and record actual execution times against the performance goals (T021)
+2. Measure and record actual execution times against the performance goals (T021)
 
 **Tracking Source of Truth**: `tasks.md` is the execution tracker for the remaining work; keep it synchronized when implementation lands outside Speckit commands
 

--- a/specs/002-storybook-e2e-testing/plan.md
+++ b/specs/002-storybook-e2e-testing/plan.md
@@ -117,8 +117,8 @@ This feature establishes a two-phase E2E testing strategy to address the inabili
 **Status**: COMPLETED - `tasks.md` exists and implementation work has progressed substantially outside the original Speckit command flow
 
 **Current execution snapshot (2026-05-18)**:
-- Completed: Playwright Storybook project/config, shared Storybook helpers, context-agnostic page objects, ItemForm/TouchButton/CreateTagDialog test coverage, test pattern catalog, CI/CD guidance, and root-level npm scripts/README updates
-- Still open in `tasks.md`: touch-optimization refactor, LongPressContextMenu coverage, additional component coverage, quickstart refresh, and performance measurement
+- Completed: Playwright Storybook project/config, shared Storybook helpers, context-agnostic page objects, ItemForm/TouchButton/CreateTagDialog/LongPressContextMenu/SearchBar/TagSelector test coverage, test pattern catalog, CI/CD guidance, and root-level npm scripts/README updates
+- Still open in `tasks.md`: touch-optimization refactor, quickstart refresh, and performance measurement
 
 **Next Action**: Keep `tasks.md` current as implementation continues; use `/speckit.analyze spec 002` or manual artifact updates to re-sync after major work lands outside the workflow
 
@@ -205,10 +205,8 @@ playwright.config.js              # Storybook + app projects with optional auto-
 
 **Remaining Critical Path**:
 1. Finish touch-optimization refactor (T012b)
-2. Add LongPressContextMenu Storybook coverage (T015)
-3. Expand coverage to additional critical components (T016)
-4. Refresh quickstart examples based on shipped patterns (T018)
-5. Measure and record actual execution times against the performance goals (T021)
+2. Refresh quickstart examples based on shipped patterns (T018)
+3. Measure and record actual execution times against the performance goals (T021)
 
 **Tracking Source of Truth**: `tasks.md` is the execution tracker for the remaining work; keep it synchronized when implementation lands outside Speckit commands
 

--- a/specs/002-storybook-e2e-testing/plan.md
+++ b/specs/002-storybook-e2e-testing/plan.md
@@ -117,10 +117,24 @@ This feature establishes a two-phase E2E testing strategy to address the inabili
 **Status**: COMPLETED - `tasks.md` exists and implementation work has progressed substantially outside the original Speckit command flow
 
 **Current execution snapshot (2026-05-18)**:
-- Completed: Playwright Storybook project/config, shared Storybook helpers, context-agnostic page objects, touch-optimization app refactor, ItemForm/TouchButton/CreateTagDialog/LongPressContextMenu/SearchBar/TagSelector test coverage, test pattern catalog, CI/CD guidance, and root-level npm scripts/README updates
-- Still open in `tasks.md`: performance measurement
+- Completed: Playwright Storybook project/config, shared Storybook helpers, context-agnostic page objects, touch-optimization app refactor, ItemForm/TouchButton/CreateTagDialog/LongPressContextMenu/SearchBar/TagSelector test coverage, test pattern catalog, performance measurement, CI/CD guidance, and root-level npm scripts/README updates
+- Still open in `tasks.md`: none for spec 002 implementation; draft PR review/merge remains outside the task list
 
-**Next Action**: Keep `tasks.md` current as implementation continues; use `/speckit.analyze spec 002` or manual artifact updates to re-sync after major work lands outside the workflow
+**Next Action**: Review draft PR #73 and keep `tasks.md` current if any review follow-ups are requested
+
+### Performance Measurement Results (T021)
+
+Measured on 2026-05-18 using Playwright-managed local servers from the repository root.
+
+| Suite | Command | Result | Reported duration | Wall-clock duration | Goal | Status |
+|-------|---------|--------|-------------------|---------------------|------|--------|
+| Storybook component tests | `npx playwright test tests/e2e/storybook --project=storybook-chromium --reporter=line` | 30 passed, 3 skipped | 51.5s suite total | 52s | <30s per component story | ✅ Pass |
+| Storybook slowest individual test/story | JSON reporter parse of the same Storybook project | `LongPressContextMenu` action-selection test | 1.36s | N/A | <30s per component story | ✅ Pass |
+| Full app E2E tests | `npx playwright test tests/e2e/app --project=chromium --reporter=line` | 45 passed | 1.9m suite total | 113s | <5min full E2E suite | ✅ Pass |
+
+**Optimization notes**:
+- No blocking optimization is required; both measured goals pass comfortably.
+- Optional future improvement: app-only runs currently still pay the shared Playwright `webServer` startup cost for Storybook because both servers are configured globally. If app suite runtime becomes tight, split server startup by project or use `PLAYWRIGHT_SKIP_WEBSERVER=1` with already-running local servers for faster iteration.
 
 ## Project Structure
 
@@ -181,8 +195,8 @@ playwright.config.js              # Storybook + app projects with optional auto-
 ## Planning Summary
 
 **Branch**: `002-storybook-e2e-testing`
-**Status**: 🔄 Implementation underway; artifacts synced with out-of-band work on 2026-05-18
-**Next Step**: Finish the remaining open tasks in `tasks.md` and keep these artifacts updated as the implementation evolves
+**Status**: ✅ Implementation complete for the tracked spec 002 follow-up tasks; artifacts synced with out-of-band work on 2026-05-18
+**Next Step**: Review draft PR #73 and keep these artifacts updated if review follow-ups change scope or status
 
 **Artifacts Created**:
 - ✅ `plan.md` - This file, comprehensive implementation plan
@@ -203,8 +217,7 @@ playwright.config.js              # Storybook + app projects with optional auto-
 5. **Practical debugging guide**: quickstart.md and ci-cd.md address local and CI pain points
 6. **Flexible execution modes**: auto-start works for convenience; skip-server mode supports rapid local iteration
 
-**Remaining Critical Path**:
-1. Measure and record actual execution times against the performance goals (T021)
+**Remaining Critical Path**: Complete for the tracked spec 002 implementation tasks. Draft PR review/merge remains the next project workflow step.
 
 **Tracking Source of Truth**: `tasks.md` is the execution tracker for the remaining work; keep it synchronized when implementation lands outside Speckit commands
 

--- a/specs/002-storybook-e2e-testing/plan.md
+++ b/specs/002-storybook-e2e-testing/plan.md
@@ -117,8 +117,8 @@ This feature establishes a two-phase E2E testing strategy to address the inabili
 **Status**: COMPLETED - `tasks.md` exists and implementation work has progressed substantially outside the original Speckit command flow
 
 **Current execution snapshot (2026-05-18)**:
-- Completed: Playwright Storybook project/config, shared Storybook helpers, context-agnostic page objects, ItemForm/TouchButton/CreateTagDialog/LongPressContextMenu/SearchBar/TagSelector test coverage, test pattern catalog, CI/CD guidance, and root-level npm scripts/README updates
-- Still open in `tasks.md`: touch-optimization refactor and performance measurement
+- Completed: Playwright Storybook project/config, shared Storybook helpers, context-agnostic page objects, touch-optimization app refactor, ItemForm/TouchButton/CreateTagDialog/LongPressContextMenu/SearchBar/TagSelector test coverage, test pattern catalog, CI/CD guidance, and root-level npm scripts/README updates
+- Still open in `tasks.md`: performance measurement
 
 **Next Action**: Keep `tasks.md` current as implementation continues; use `/speckit.analyze spec 002` or manual artifact updates to re-sync after major work lands outside the workflow
 
@@ -204,8 +204,7 @@ playwright.config.js              # Storybook + app projects with optional auto-
 6. **Flexible execution modes**: auto-start works for convenience; skip-server mode supports rapid local iteration
 
 **Remaining Critical Path**:
-1. Finish touch-optimization refactor (T012b)
-2. Measure and record actual execution times against the performance goals (T021)
+1. Measure and record actual execution times against the performance goals (T021)
 
 **Tracking Source of Truth**: `tasks.md` is the execution tracker for the remaining work; keep it synchronized when implementation lands outside Speckit commands
 

--- a/specs/002-storybook-e2e-testing/quickstart.md
+++ b/specs/002-storybook-e2e-testing/quickstart.md
@@ -500,7 +500,6 @@ Before committing new tests:
 
 After mastering this workflow:
 
-	1. **Finish touch-optimization refactor (T012b)**: Port the proven Storybook selector and touch-target patterns into `tests/e2e/app/touch-optimization.spec.ts`.
-	2. **Measure performance goals (T021)**: Record Storybook and full-app execution times back in `tasks.md`/`plan.md` when measured.
-	3. **Repair/expand full-app E2E**: Keep porting proven Storybook selectors/page objects into `tests/e2e/app/` and record current app-suite status separately.
-	4. **Maintain documentation**: Update `test-patterns.md`, this quickstart, and the story inventory whenever new patterns or stories become part of the testing contract.
+	1. **Measure performance goals (T021)**: Record Storybook and full-app execution times back in `tasks.md`/`plan.md` when measured.
+	2. **Repair/expand full-app E2E**: Keep porting proven Storybook selectors/page objects into `tests/e2e/app/` and record current app-suite status separately.
+	3. **Maintain documentation**: Update `test-patterns.md`, this quickstart, and the story inventory whenever new patterns or stories become part of the testing contract.

--- a/specs/002-storybook-e2e-testing/quickstart.md
+++ b/specs/002-storybook-e2e-testing/quickstart.md
@@ -7,7 +7,7 @@
 
 **Current coverage snapshot**:
 - Storybook project/config exists in `playwright.config.js` as `storybook-chromium`.
-- Storybook component tests exist for `ItemForm`, `CreateTagDialog`, `TouchButton`, and Storybook helper behavior.
+- Storybook component tests exist for `ItemForm`, `CreateTagDialog`, `TouchButton`, `LongPressContextMenu`, `SearchBar`, and `TagSelector`, plus Storybook helper behavior.
 - Full-app tests exist under `tests/e2e/app/`; their current repair status is tracked in `tasks.md` and implementation tracker docs, not assumed green here.
 
 ## Prerequisites
@@ -49,6 +49,12 @@ npm run test:e2e:app -- --project=chromium
 
 # Run specific component test
 npm run test:e2e:storybook -- tests/e2e/storybook/ItemForm.spec.ts --project=storybook-chromium
+
+# Run a callback-driven harness example
+npm run test:e2e:storybook -- tests/e2e/storybook/SearchBar.spec.ts --project=storybook-chromium
+
+# Run a touch-target example
+npm run test:e2e:storybook -- tests/e2e/storybook/TagSelector.spec.ts --project=storybook-chromium
 
 # Run with UI (headed mode) for debugging
 npm run test:e2e:headed -- tests/e2e/storybook/ItemForm.spec.ts --project=storybook-chromium
@@ -184,6 +190,71 @@ export class ItemFormPage {
 
 ---
 
+## US3 Examples: Callback Harnesses and Touch Targets
+
+### Example: SearchBar callback-driven behavior
+
+`SearchBar` is a good example of a component whose important behavior is mostly callback-driven. The `TestInteractions` story keeps the component realistic while rendering callback results into the DOM.
+
+```typescript
+test('should update query and execute search on Enter', async ({ page }) => {
+  await gotoStory(page, 'ui-searchbar', 'test-interactions');
+
+  const input = page.getByRole('textbox', { name: 'Search query' });
+  await input.fill('camp stove');
+  await input.press('Enter');
+
+  await expect(page.getByTestId('last-search')).toHaveText('camp stove');
+  await expect(page.getByTestId('search-count')).toHaveText('1');
+});
+```
+
+**Why this pattern matters**:
+- Storybook action logs are useful for manual inspection, but Playwright needs deterministic DOM-visible state.
+- The harness keeps selectors user-facing (`role`, accessible name) and reserves `data-testid` for test-only state.
+- The same story also validates scoped search UI and clear-button touch targets.
+
+### Example: TagSelector hidden-input + touch-target behavior
+
+`TagSelector` uses Grommet `CheckBox`, which renders a hidden native input. The reliable test target is the visible label/touch area, not the hidden input itself.
+
+```typescript
+test('should keep tag rows touch-friendly', async ({ page }) => {
+  await gotoStory(page, 'ui-tagselector', 'test-interactions');
+
+  const touchTarget = page.getByTestId('tag-touch-target-tag3');
+  const box = await touchTarget.boundingBox();
+
+  if (box === null) throw new Error('Tag touch target is not visible');
+  expect(box.height).toBeGreaterThanOrEqual(44);
+});
+```
+
+**What changed after T016**:
+- The visible label content now exposes a real 44px touch target.
+- Tests click the visible row/test harness target instead of trying to `check()` the hidden native input.
+- This is the pattern to reuse when porting touch-heavy checkbox interactions into full-app tests.
+
+### Example: LongPressContextMenu gesture timing
+
+`LongPressContextMenu` is the main US3 example where one intentional gesture delay is still appropriate. Keep the threshold wait inside a single helper that matches the component's long-press contract instead of scattering arbitrary waits throughout the test.
+
+```typescript
+const longPress = async (page: Page, target: Locator): Promise<void> => {
+  const box = await target.boundingBox();
+  if (box === null) throw new Error('Long-press target is not visible');
+
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.waitForTimeout(600);
+  await page.mouse.up();
+};
+```
+
+**Rule of thumb**: fixed waits are still an anti-pattern for general readiness checks, but gesture-threshold waits are acceptable when they model the product behavior directly and stay encapsulated in one helper.
+
+---
+
 ## Workflow: Porting to Integration Test
 
 ### Step 1: Verify Component Test Passes
@@ -299,6 +370,18 @@ export class ItemFormPage {
 
 **Common cause**: Element inside modal in full app, but not in Storybook. Usually selectors still work - verify with Inspector.
 
+### Issue: Callback-driven story works manually, but test has nothing stable to assert
+
+**Symptom**: You can see Storybook actions firing, but Playwright has no deterministic DOM change to assert.
+
+**Debug steps**:
+1. Add a dedicated `TestInteractions` story instead of overloading the visual/default story.
+2. Render callback counts and last payloads with `data-testid` values like `last-search`, `search-count`, or `last-toggle`.
+3. Keep the component interaction realistic - user-facing controls should still use `getByRole()` / accessible names.
+4. Re-run the Storybook test before porting anything to the full app.
+
+**Common cause**: Relying on Storybook actions or console logging instead of DOM-visible harness state.
+
 ### Issue: Form doesn't submit in test
 
 **Symptom**: Button clicks, but form doesn't submit (modal stays open)
@@ -318,6 +401,30 @@ export class ItemFormPage {
 4. Check browser console for JavaScript errors (run with `--headed`)
 
 **Common cause**: In Grommet forms, sometimes Enter key doesn't work - always click button explicitly.
+
+### Issue: Grommet checkbox exists, but clicking/checking is flaky or misses the touch target
+
+**Symptom**: `getByRole('checkbox')` resolves, but the interaction is unreliable, or the measured touch area is smaller than 44px.
+
+**Debug steps**:
+1. Confirm whether the component uses Grommet `CheckBox` with a hidden native input.
+2. Target the visible label/touch area instead of the hidden input.
+3. Measure the visible interactive element with `boundingBox()` - not just a surrounding container.
+4. If the visible label is undersized, fix the component so the label content itself reaches the 44px minimum.
+
+**Common cause**: The native checkbox input is hidden, and the visually large row is not the real clickable element.
+
+### Issue: Long-press menu never opens in Storybook
+
+**Symptom**: The menu is never shown even though the pointer is over the correct target.
+
+**Debug steps**:
+1. Verify the story renders a deterministic long-press target such as `data-testid="long-press-target"`.
+2. Use a helper that presses down, waits for the component's configured threshold, and then releases.
+3. Keep that delay isolated to the long-press helper; do not translate it into generic waits elsewhere.
+4. Assert the menu container directly (`context-menu`) after the gesture.
+
+**Common cause**: The test releases too quickly, so it performs a click/tap instead of a long press.
 
 ### Issue: Test is flaky (passes sometimes, fails sometimes)
 
@@ -358,6 +465,8 @@ export class ItemFormPage {
 - **Test one interaction pattern at a time** in ComponentTest
 - **Document known issues** when selectors/patterns differ between contexts
 - **Run tests frequently** during development (fast iteration on Storybook tests)
+- **Use deterministic harness stories** for callback-driven components instead of asserting Storybook actions
+- **Measure the visible interactive element** when validating 44px touch targets
 
 ### DON'T ❌
 
@@ -367,6 +476,7 @@ export class ItemFormPage {
 - **Don't test Storybook UI chrome** - always use `iframe.html` view
 - **Don't assume component behavior** - run tests to verify, don't claim "it works" without proof
 - **Don't mix component and integration concerns** - keep test files separated
+- **Don't assert against hidden native inputs** when Grommet renders a separate visible label target
 
 ---
 
@@ -390,7 +500,7 @@ Before committing new tests:
 
 After mastering this workflow:
 
-	1. **Finish open Storybook backlog**: Add `LongPressContextMenu` coverage and any additional critical component tests identified in `storybook-stories-inventory.md`.
-	2. **Repair/expand full-app E2E**: Keep porting proven Storybook selectors/page objects into `tests/e2e/app/` and record current app-suite status separately.
-	3. **Measure performance goals**: Record Storybook and full-app execution times back in `tasks.md`/`plan.md` when measured.
+	1. **Finish touch-optimization refactor (T012b)**: Port the proven Storybook selector and touch-target patterns into `tests/e2e/app/touch-optimization.spec.ts`.
+	2. **Measure performance goals (T021)**: Record Storybook and full-app execution times back in `tasks.md`/`plan.md` when measured.
+	3. **Repair/expand full-app E2E**: Keep porting proven Storybook selectors/page objects into `tests/e2e/app/` and record current app-suite status separately.
 	4. **Maintain documentation**: Update `test-patterns.md`, this quickstart, and the story inventory whenever new patterns or stories become part of the testing contract.

--- a/specs/002-storybook-e2e-testing/storybook-stories-inventory.md
+++ b/specs/002-storybook-e2e-testing/storybook-stories-inventory.md
@@ -99,7 +99,7 @@
 - `ui-longpresscontextmenu--touch-targets`
 - `ui-longpresscontextmenu--test-interactions` (deterministic Playwright harness)
 
-**Recommended for US3 Testing** (T015). No Playwright Storybook spec exists yet.
+**Current Playwright coverage**: `tests/e2e/storybook/LongPressContextMenu.spec.ts` (T015 ✅)
 
 ## Additional Available Stories
 
@@ -121,6 +121,15 @@ All stories located in `meteor-app/imports/ui/*.stories.tsx`:
 - SwipeNavigation
 - TagChip
 - TagSelector
+
+### T016 Coverage Additions
+
+- `SearchBar`
+  - Story IDs include `ui-searchbar--test-interactions` for deterministic Playwright coverage
+  - Current Playwright coverage: `tests/e2e/storybook/SearchBar.spec.ts`
+- `TagSelector`
+  - Story IDs include `ui-tagselector--test-interactions` for deterministic Playwright coverage
+  - Current Playwright coverage: `tests/e2e/storybook/TagSelector.spec.ts`
 
 ## Story ID Format
 
@@ -152,4 +161,4 @@ await gotoStory(page, 'ui-itemform', 'create-mode');
 
 - MVP stories exist and are covered for ItemForm; TouchButton and CreateTagDialog also have Storybook Playwright specs.
 - LongPressContextMenu stories are complete; Playwright coverage added via `TestInteractions` harness (T015 ✅).
-- Additional stories remain available for comprehensive coverage in T016; prioritize critical user workflows before visual-only states.
+- SearchBar and TagSelector coverage added for T016; remaining uncovered stories can be prioritized by critical user workflow before visual-only states.

--- a/specs/002-storybook-e2e-testing/tasks.md
+++ b/specs/002-storybook-e2e-testing/tasks.md
@@ -167,12 +167,12 @@
   - **Follow-up Watchpoint**: keep selectors aligned if the UI button copy/icon treatment changes again
   - **Notes**: Core routing functionality verified in T017 (spec-003) - URL navigation works correctly
 
-- [ ] T012b [US2] Port proven patterns to touch optimization tests in tests/e2e/app/touch-optimization.spec.ts
-  - Refactor existing tests to use proven selector patterns
-  - Replace any getByLabel() with name attribute selectors
-  - Ensure tests use Playwright auto-waiting (no fixed timeouts)
-  - Test: "Long-press context menu"
-  - Test: "Swipe-back navigation"
+- [x] T012b [US2] Port proven patterns to touch optimization tests in tests/e2e/app/touch-optimization.spec.ts
+  - Refactored touch optimization tests to use shared page objects, role/name selectors, and `data-testid` selectors for touch-specific probes
+  - Removed the remaining actual `getByLabel()` usage from `ItemFormPage`; Grommet checkbox interaction now uses the visible label/touch target while asserting checked state through `input[name="isContainer"]`
+  - Replaced arbitrary fixed waits with Playwright assertions/auto-waiting; the only remaining timeout is encapsulated in the long-press helper because it models the component's gesture threshold
+  - Revalidated long-press context menu and swipe-back navigation in `tests/e2e/app/touch-optimization.spec.ts`
+  - Focused app touch suite passing: 8/8 tests (Green)
 
 ### Page Objects for User Story 2
 
@@ -183,10 +183,10 @@
   - **Pattern compliance**: Uses name/type/data-testid selectors only
   - **Notes**: Additional specialized page objects can be created as needed for specific features
 
-**Checkpoint**: User Story 2 is largely implemented - proven patterns are applied to multiple workflows. Can demonstrate:
+**Checkpoint**: User Story 2 is implemented - proven patterns are applied to multiple workflows. Can demonstrate:
 - ✅ Multiple ComponentTests passing in Storybook
 - ✅ Multiple IntegrationTests using same page objects
-- 🔄 Remaining work captured for touch/mobile interaction coverage (T012b)
+- ✅ Touch/mobile interaction coverage uses proven selector and auto-waiting patterns (T012b)
 
 ---
 

--- a/specs/002-storybook-e2e-testing/tasks.md
+++ b/specs/002-storybook-e2e-testing/tasks.md
@@ -240,16 +240,16 @@
   - **Content Includes**: Selectors, interaction sequences, assertions, known issues, examples
   - **Reference Tests**: ItemFormPage, TouchButton, CreateTagDialog
   - **Anti-Patterns**: Documented common mistakes to avoid
-- [ ] T018 [US3] Update quickstart.md with additional examples
-  - Add examples for newly tested components
-  - Document any edge cases discovered during US3
-  - Update debugging section with new common issues
+- [x] T018 [US3] Update quickstart.md with additional examples
+  - Added SearchBar and TagSelector examples showing deterministic harness-story assertions and visible touch-target validation
+  - Documented US3 edge cases for callback-driven stories, Grommet hidden checkbox inputs, and long-press gesture timing
+  - Updated debugging, best-practices, quick-reference, and next-step guidance to reflect T015/T016 outcomes
 
-**Checkpoint Target**: Once T015, T016, and T018 are complete, User Story 3 will provide comprehensive component coverage. Current state:
+**Checkpoint Target**: T015, T016, and T018 are complete; User Story 3 now provides comprehensive component coverage. Current state:
 - ✅ ItemForm has extended Storybook coverage
 - ✅ LongPressContextMenu, SearchBar, and TagSelector have Storybook Playwright coverage
 - ✅ Pattern documentation exists for newly proven workflows
-- 🔄 Quickstart refresh remains open
+- ✅ Quickstart examples and debugging guidance are refreshed
 
 ---
 

--- a/specs/002-storybook-e2e-testing/tasks.md
+++ b/specs/002-storybook-e2e-testing/tasks.md
@@ -218,11 +218,12 @@
   - Added `TestInteractions` story to `LongPressContextMenu.stories.tsx` as deterministic test harness
   - Tests: show menu on long press, hide menu on outside click, execute menu action on selection
   - All 3 tests passing (Green)
-- [ ] T016 [P] [US3] Create additional critical component tests
-  - Identify remaining critical components from meteor-app/imports/ui/*.stories.tsx
-  - Create ComponentTests for each
-  - Follow proven patterns from US1 and US2
-  - Document any new patterns discovered
+- [x] T016 [P] [US3] Create additional critical component tests
+  - Added `tests/e2e/storybook/SearchBar.spec.ts` for query updates, Enter search, clear behavior, scoped label, and clear-button touch target
+  - Added `tests/e2e/storybook/TagSelector.spec.ts` for tag toggling, create callback, and 44px tag touch targets
+  - Added deterministic `TestInteractions` stories for SearchBar and TagSelector
+  - Improved TagSelector label touch targets to expose a real 44px clickable area
+  - All 6 tests passing (Green)
 
 ### Process & Documentation for User Story 3
 
@@ -246,8 +247,9 @@
 
 **Checkpoint Target**: Once T015, T016, and T018 are complete, User Story 3 will provide comprehensive component coverage. Current state:
 - ✅ ItemForm has extended Storybook coverage
+- ✅ LongPressContextMenu, SearchBar, and TagSelector have Storybook Playwright coverage
 - ✅ Pattern documentation exists for newly proven workflows
-- 🔄 Additional component coverage and quickstart refresh remain open
+- 🔄 Quickstart refresh remains open
 
 ---
 

--- a/specs/002-storybook-e2e-testing/tasks.md
+++ b/specs/002-storybook-e2e-testing/tasks.md
@@ -274,11 +274,12 @@
     - Link to comprehensive quickstart guide
   - **Location**: /home/wsl/workspace/my-inventory-app/README.md
   - **Benefits**: Clear onboarding for new developers, documented testing workflow
-- [ ] T021 Validate test performance goals from plan.md
-  - Measure ComponentTest execution time (goal: <30s per story)
-  - Measure full E2E suite time (goal: <5min)
-  - Document actual performance in plan.md
-  - Identify optimization opportunities if goals not met
+- [X] T021 Validate test performance goals from plan.md
+  - **Status**: COMPLETED ✅
+  - **Storybook suite**: `npx playwright test tests/e2e/storybook --project=storybook-chromium --reporter=line` → 30 passed, 3 skipped; 51.5s reported / 52s wall-clock
+  - **Per-story check**: JSON reporter parse found slowest individual Storybook test/story at 1.36s (`LongPressContextMenu` action-selection test), below the <30s goal
+  - **Full app suite**: `npx playwright test tests/e2e/app --project=chromium --reporter=line` → 45 passed; 1.9m reported / 113s wall-clock, below the <5min goal
+  - **Optimization notes**: No blocking optimization needed; optional future improvement is splitting Playwright `webServer` startup by project so app-only runs do not start Storybook
 - [X] T022 [P] Create CI/CD guidance in specs/002-storybook-e2e-testing/ci-cd.md
   - **Status**: COMPLETED ✅
   - **Content Created**:
@@ -295,7 +296,7 @@
   - **Location**: /home/wsl/workspace/my-inventory-app/specs/002-storybook-e2e-testing/ci-cd.md
   - **Workflows Covered**: Two-stage pipeline, parallel execution, conditional execution based on file changes
 
-**Implementation Snapshot**: Core two-phase testing strategy is implemented, with a small follow-up backlog still open in this file
+**Implementation Snapshot**: Core two-phase testing strategy and tracked spec 002 follow-up backlog are complete; draft PR review/merge remains outside this task list
 
 ---
 

--- a/specs/002-storybook-e2e-testing/test-patterns.md
+++ b/specs/002-storybook-e2e-testing/test-patterns.md
@@ -4,7 +4,7 @@
 
 **Status**: Living document - update as new patterns are discovered
 
-**Last synced**: 2026-05-18 against current Storybook specs (`ItemForm`, `CreateTagDialog`, `TouchButton`) and app E2E helpers.
+**Last synced**: 2026-05-18 against current Storybook specs (`ItemForm`, `CreateTagDialog`, `TouchButton`, `LongPressContextMenu`, `SearchBar`, `TagSelector`) and app E2E helpers.
 
 ---
 
@@ -586,6 +586,72 @@ await page.locator('.sc-aXZVg').click();
 
 ---
 
+## Pattern 8: Deterministic Interaction Harness Stories
+
+**Status**: ✅ Validated in Storybook (T015, T016)
+
+**Use Case**: Testing callback-driven components that do not naturally render callback state in the DOM.
+
+**Problem Solved**: Storybook actions and console logs are useful for humans, but Playwright needs deterministic DOM-visible state for assertions.
+
+### Selectors Used
+
+```typescript
+await gotoStory(page, 'ui-searchbar', 'test-interactions');
+await page.getByRole('textbox', { name: 'Search query' }).fill('camp stove');
+await page.getByRole('textbox', { name: 'Search query' }).press('Enter');
+await expect(page.getByTestId('last-search')).toHaveText('camp stove');
+```
+
+### Harness Requirements
+
+1. Render callback counts and last callback payloads with `data-testid` attributes.
+2. Keep the component under test realistic; do not bypass normal user interactions.
+3. Use accessible selectors for user-facing controls, and `data-testid` only for harness state or intentional touch-target probes.
+
+### References
+
+- Validated in: `tests/e2e/storybook/LongPressContextMenu.spec.ts` (T015)
+- Validated in: `tests/e2e/storybook/SearchBar.spec.ts` (T016)
+- Validated in: `tests/e2e/storybook/TagSelector.spec.ts` (T016)
+
+---
+
+## Pattern 9: Grommet CheckBox Touch Target Pattern
+
+**Status**: ✅ Validated in Storybook (T016)
+
+**Use Case**: Verifying touch-friendly checkbox rows when Grommet renders the native checkbox input as hidden.
+
+**Problem Solved**: `getByRole('checkbox').check()` can resolve to a hidden native input. The visible label may also be smaller than the required 44px touch target unless the label content is explicitly sized.
+
+### Selectors Used
+
+```typescript
+await page.getByTestId('tag-touch-target-tag2').click();
+const box = await page.getByTestId('tag-touch-target-tag2').boundingBox();
+expect(box?.height).toBeGreaterThanOrEqual(44);
+```
+
+### Component Pattern
+
+```tsx
+<CheckBox
+  label={
+    <Box data-testid={`tag-touch-target-${tag._id}`} justify="center" style={{ minHeight: '44px' }}>
+      <Text>{tag.name}</Text>
+    </Box>
+  }
+/>
+```
+
+### References
+
+- Validated in: `tests/e2e/storybook/TagSelector.spec.ts` (T016)
+- Component: `meteor-app/imports/ui/TagSelector.tsx`
+
+---
+
 ## Pattern Summary Table
 
 | Pattern | Status | Storybook Test | Integration Test | Key Challenge |
@@ -597,6 +663,8 @@ await page.locator('.sc-aXZVg').click();
 | Grommet CheckBox | ✅ Validated | T014 | N/A | Hidden native input |
 | Context-Agnostic Page Objects | ✅ Core Pattern | All | All | Navigation differences |
 | TouchButton Interaction | ✅ Validated | T010 | T012b pending | Separate semantic behavior from visual/touch metrics |
+| Deterministic Interaction Harness | ✅ Validated | T015, T016 | N/A | DOM-visible callback assertions |
+| Grommet CheckBox Touch Target | ✅ Validated | T016 | N/A | Hidden native input and undersized visible labels |
 
 ---
 

--- a/specs/002-storybook-e2e-testing/test-patterns.md
+++ b/specs/002-storybook-e2e-testing/test-patterns.md
@@ -560,7 +560,7 @@ test('should submit form', async ({ page }) => {
 
 ## Pattern 7: TouchButton Interaction Pattern
 
-**Status**: ✅ Validated in Storybook (T010) | 🔄 Full touch-optimization refactor remains tracked separately (T012b)
+**Status**: ✅ Validated in Storybook (T010) | ✅ Ported to touch-optimization app coverage (T012b)
 
 **Use Case**: Testing touch-optimized button states and variants without coupling to layout-specific visual details.
 
@@ -662,7 +662,7 @@ expect(box?.height).toBeGreaterThanOrEqual(44);
 | Double-Submit Prevention | ✅ Validated | T014, T011 | T012 | Requires realistic delays |
 | Grommet CheckBox | ✅ Validated | T014 | N/A | Hidden native input |
 | Context-Agnostic Page Objects | ✅ Core Pattern | All | All | Navigation differences |
-| TouchButton Interaction | ✅ Validated | T010 | T012b pending | Separate semantic behavior from visual/touch metrics |
+| TouchButton Interaction | ✅ Validated | T010 | T012b | Separate semantic behavior from visual/touch metrics |
 | Deterministic Interaction Harness | ✅ Validated | T015, T016 | N/A | DOM-visible callback assertions |
 | Grommet CheckBox Touch Target | ✅ Validated | T016 | N/A | Hidden native input and undersized visible labels |
 

--- a/tests/e2e/app/touch-optimization.spec.ts
+++ b/tests/e2e/app/touch-optimization.spec.ts
@@ -12,19 +12,73 @@
  * Tests use mobile viewport to simulate touch interactions on iPad/iPhone.
  */
 
-import { expect, test } from '@playwright/test';
+import { expect, type Locator, type Page, test } from '@playwright/test';
 
 import { callMeteorMethod, resetDatabase, waitForMeteorReady } from '../helpers/database';
 import { InventoryPage, ItemFormPage } from '../helpers/page-objects';
 
+const MOBILE_VIEWPORT = { width: 375, height: 667 } as const;
+const MIN_TAP_SIZE_PX = 44;
+const LONG_PRESS_DURATION_MS = 600;
+const PULL_TO_REFRESH_DISTANCE_PX = 180;
+const SWIPE_BACK_START_X_PX = 10;
+const SWIPE_BACK_END_X_PX = 150;
+
+const expectInventoryReady = async (page: Page): Promise<void> => {
+    await waitForMeteorReady(page);
+    await expect(page.getByRole('heading', { name: 'Inventory App' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Items' })).toBeVisible();
+};
+
+const getItemsList = (page: Page): Locator => page.getByTestId('items-list');
+
+const requireBoundingBox = async (
+    locator: Locator,
+    label: string
+): Promise<NonNullable<Awaited<ReturnType<Locator['boundingBox']>>>> => {
+    const box = await locator.boundingBox();
+    if (box === null) throw new Error(`${label} is not visible`);
+    return box;
+};
+
+const expectTouchTargetSize = async (locator: Locator, label: string): Promise<void> => {
+    const box = await requireBoundingBox(locator, label);
+    expect(box.width, `${label} width`).toBeGreaterThanOrEqual(MIN_TAP_SIZE_PX);
+    expect(box.height, `${label} height`).toBeGreaterThanOrEqual(MIN_TAP_SIZE_PX);
+};
+
+const dragPointer = async (
+    page: Page,
+    start: { x: number; y: number },
+    end: { x: number; y: number },
+    steps = 10
+): Promise<void> => {
+    await page.mouse.move(start.x, start.y);
+    await page.mouse.down();
+    await page.mouse.move(end.x, end.y, { steps });
+};
+
+const releasePointer = async (page: Page): Promise<void> => {
+    await page.mouse.up();
+};
+
+const longPress = async (page: Page, target: Locator): Promise<void> => {
+    const box = await requireBoundingBox(target, 'Long-press target');
+
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+
+    // Intentional gesture threshold wait: models the component's 500ms long-press contract.
+    await page.waitForTimeout(LONG_PRESS_DURATION_MS);
+    await releasePointer(page);
+};
+
 test.describe('Touch Optimization - User Story 5', () => {
     test.beforeEach(async ({ page }) => {
-        // Reset database before each test
+        await page.setViewportSize(MOBILE_VIEWPORT);
         await resetDatabase(page);
-
-        // Navigate to app
         await page.goto('/');
-        await waitForMeteorReady(page);
+        await expectInventoryReady(page);
     });
 
     /**
@@ -36,12 +90,6 @@ test.describe('Touch Optimization - User Story 5', () => {
      * - Elements include navigation buttons, action buttons, list items, form inputs
      */
     test('T053a: All tap targets meet 44×44px minimum on mobile viewport', async ({ page }) => {
-        // Set viewport to iPhone size (375x667)
-        await page.setViewportSize({ width: 375, height: 667 });
-
-        // Wait for page to load
-        await page.waitForSelector('text=Inventory App');
-
         // Get all interactive elements
         const interactiveSelectors = [
             'button',
@@ -53,7 +101,6 @@ test.describe('Touch Optimization - User Story 5', () => {
             'select',
         ];
 
-        const minTapSize = 44;
         const failedElements: Array<{
             selector: string;
             width: number;
@@ -74,7 +121,7 @@ test.describe('Touch Optimization - User Story 5', () => {
                 if (!box) continue;
 
                 // Check if meets minimum tap target size
-                if (box.width < minTapSize || box.height < minTapSize) {
+                if (box.width < MIN_TAP_SIZE_PX || box.height < MIN_TAP_SIZE_PX) {
                     const elementText = await element.textContent();
                     failedElements.push({
                         selector: `${selector} ("${elementText?.slice(0, 30) ?? ''}")`,
@@ -106,36 +153,21 @@ test.describe('Touch Optimization - User Story 5', () => {
      * - Works on both items and containers
      */
     test('T053b: Long-press on item reveals context menu', async ({ page }) => {
-        // Set viewport to iPhone size
-        await page.setViewportSize({ width: 375, height: 667 });
-
         // Seed a test item; creation form behavior is covered by item-creation specs.
         await callMeteorMethod<string>(page, 'items.createItem', { name: 'Test Item for Long Press' });
         await page.reload();
-        await waitForMeteorReady(page);
-
-        // Wait for item to appear in the list
-        await page.waitForSelector('text=Test Item for Long Press');
+        await expectInventoryReady(page);
 
         // Find the item in the list
-        const itemLocator = page.locator('text=Test Item for Long Press').first();
+        const itemLocator = getItemsList(page).getByText('Test Item for Long Press', { exact: true });
+        await expect(itemLocator).toBeVisible();
 
-        // Long-press on the item (500ms+ to trigger context menu).
-        const box = await itemLocator.boundingBox();
-        if (!box) throw new Error('Item not found');
-
-        await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
-        await page.mouse.down();
-        await page.waitForTimeout(600);
+        await longPress(page, itemLocator);
 
         // Check if context menu is visible with expected actions
-        const contextMenu = page
-            .locator('[data-testid="context-menu"]')
-            .or(page.locator('text="View Details"').or(page.locator('text="Edit"').or(page.locator('text="Delete"'))));
-
-        // At least one context menu action should be visible
-        await expect(contextMenu.first()).toBeVisible({ timeout: 1000 });
-        await page.mouse.up();
+        const contextMenu = page.getByTestId('context-menu');
+        await expect(contextMenu).toBeVisible();
+        await expect(contextMenu.getByText('View Details', { exact: true })).toBeVisible();
     });
 
     /**
@@ -147,20 +179,11 @@ test.describe('Touch Optimization - User Story 5', () => {
      * - Data refreshes after pull completes
      */
     test('T053c: Pull-to-refresh works on item lists', async ({ page }) => {
-        // Set viewport to iPhone size
-        await page.setViewportSize({ width: 375, height: 667 });
-
-        await page.goto('/');
-        await page.waitForSelector('text=Inventory App');
-
         // Find the scrollable container (AllItemsView)
-        const scrollContainer = page
-            .locator('[data-testid="items-list"]')
-            .or(page.locator('text=No items at this level').locator('..').locator('..'));
+        const scrollContainer = getItemsList(page);
 
         // Get initial position
-        const box = await scrollContainer.first().boundingBox();
-        if (!box) throw new Error('Scroll container not found');
+        const box = await requireBoundingBox(scrollContainer, 'Items list');
 
         // Simulate pull-to-refresh gesture
         // Start from top of container and drag down
@@ -169,28 +192,18 @@ test.describe('Touch Optimization - User Story 5', () => {
 
         // The pull-to-refresh uses 80px trigger distance
         // We need to drag down more than that
-        await page.mouse.move(startX, startY);
-        await page.mouse.down();
-        await page.mouse.move(startX, startY + 100, { steps: 10 });
+        await dragPointer(page, { x: startX, y: startY }, { x: startX, y: startY + PULL_TO_REFRESH_DISTANCE_PX });
 
         // Check for loading indicator or refresh icon
         // The refresh indicator should be visible during pull
-        const refreshIndicator = page
-            .locator('[data-testid="pull-to-refresh-indicator"]')
-            .or(page.locator('svg').filter({ hasText: '' }));
-
-        // Wait briefly for indicator (may appear during drag)
-        await expect(refreshIndicator.first()).toBeVisible();
-        await page.waitForTimeout(200);
+        const refreshIndicator = page.getByTestId('pull-to-refresh-indicator');
+        await expect(refreshIndicator).not.toHaveCSS('opacity', '0');
 
         // Release the drag
-        await page.mouse.up();
+        await releasePointer(page);
 
-        // After release, refresh should complete
-        await page.waitForTimeout(500);
-
-        // Test passes if no errors occurred during pull gesture
-        expect(true).toBe(true);
+        // After release, the list remains usable. Refresh completion timing is covered by the hook contract.
+        await expect(scrollContainer).toBeVisible();
     });
 
     /**
@@ -202,19 +215,13 @@ test.describe('Touch Optimization - User Story 5', () => {
      * - Visual feedback during swipe
      */
     test('T053d: Swipe-back navigation works in hierarchy', async ({ page }) => {
-        // Set viewport to iPhone size
-        await page.setViewportSize({ width: 375, height: 667 });
-
-        await page.goto('/');
-        await page.waitForSelector('text=Inventory App');
-
         // Seed a container; item creation behavior is covered by item-creation specs.
         await callMeteorMethod<string>(page, 'items.createItem', {
             name: 'Parent Container',
             isContainer: true,
         });
         await page.reload();
-        await waitForMeteorReady(page);
+        await expectInventoryReady(page);
 
         // Wait for container to appear
         await expect(page.getByText('Parent Container', { exact: true })).toBeVisible({ timeout: 5000 });
@@ -230,22 +237,17 @@ test.describe('Touch Optimization - User Story 5', () => {
         const viewport = page.viewportSize();
         if (!viewport) throw new Error('No viewport');
 
-        const startX = 10; // Near left edge
+        const startX = SWIPE_BACK_START_X_PX; // Near left edge
         const startY = viewport.height / 2;
-        const endX = 150; // 140px movement (more than 100px threshold)
+        const endX = SWIPE_BACK_END_X_PX; // 140px movement (more than 100px threshold)
         const endY = startY; // Minimal vertical movement
 
         // Perform swipe gesture
-        await page.mouse.move(startX, startY);
-        await page.mouse.down();
-        await page.mouse.move(endX, endY, { steps: 10 });
-        await page.mouse.up();
+        await dragPointer(page, { x: startX, y: startY }, { x: endX, y: endY });
+        await releasePointer(page);
 
         // Should navigate back to root (All Items)
         // Breadcrumb should no longer show Parent Container as current
-        await page.waitForTimeout(500);
-
-        // Check that we're back at root by looking for the "All Items" context
         // The parent container should now be visible as an item in the list
         await expect(page.getByText('Parent Container', { exact: true })).toBeVisible({
             timeout: 2000,
@@ -261,14 +263,9 @@ test.describe('Touch Optimization - User Story 5', () => {
      * - Follows iOS design patterns
      */
     test('T053e: Visual feedback on button press (iOS-style highlight)', async ({ page }) => {
-        // Set viewport to iPhone size
-        await page.setViewportSize({ width: 375, height: 667 });
-
-        await page.goto('/');
-        await page.waitForSelector('text=Inventory App');
-
-        // Find a TouchButton (e.g., "Create Item" button)
-        const addButton = page.locator('button:has-text("Create Item")').first();
+        const inventoryPage = new InventoryPage(page);
+        const addButton = inventoryPage.addItemButton;
+        await expectTouchTargetSize(addButton, 'Create Item button');
 
         // Get initial button styles
         const initialBg = await addButton.evaluate((el) => window.getComputedStyle(el).backgroundColor);
@@ -276,9 +273,6 @@ test.describe('Touch Optimization - User Story 5', () => {
         // Simulate touch/press on button
         await addButton.hover();
         await page.mouse.down();
-
-        // Wait a brief moment for visual feedback
-        await page.waitForTimeout(50);
 
         // Get active/pressed button styles
         const pressedBg = await addButton.evaluate((el) => window.getComputedStyle(el).backgroundColor);
@@ -306,18 +300,13 @@ test.describe('Touch Optimization - User Story 5', () => {
      * - Works for all form fields
      */
     test('T053f: Keyboard does not obscure input fields (viewport adjusts)', async ({ page }) => {
-        // Set viewport to iPhone size
-        await page.setViewportSize({ width: 375, height: 667 });
-
-        await page.goto('/');
-        await page.waitForSelector('text=Inventory App');
-
-        // Open the create item form
-        await page.click('button:has-text("Create Item")');
-        await page.waitForSelector('text=Create New Item');
+        const inventoryPage = new InventoryPage(page);
+        const itemForm = new ItemFormPage(page);
+        await inventoryPage.clickCreateItem();
+        await expect(page.getByRole('heading', { name: 'Create New Item' })).toBeVisible();
 
         // Focus on the name input field
-        const nameInput = page.locator('input[name="name"]');
+        const nameInput = itemForm.nameInput;
         await nameInput.click();
 
         // Get input position before keyboard simulation
@@ -352,21 +341,18 @@ test.describe('Touch Optimization - User Story 5', () => {
      * - Visual indicator shows processing state
      */
     test('T053g: Double-tap prevention on submit buttons', async ({ page }) => {
-        // Set viewport to iPhone size
-        await page.setViewportSize({ width: 375, height: 667 });
+        const inventoryPage = new InventoryPage(page);
+        const itemForm = new ItemFormPage(page);
+        const itemName = 'Double Tap Test Item';
 
-        await page.goto('/');
-        await page.waitForSelector('text=Inventory App');
-
-        // Open the create item form
-        await page.click("button:has-text('Create Item')");
-        await page.waitForSelector('text=Create New Item');
+        await inventoryPage.clickCreateItem();
+        await expect(page.getByRole('heading', { name: 'Create New Item' })).toBeVisible();
 
         // Fill in the form
-        await page.fill('input[name="name"]', 'Double Tap Test Item');
+        await itemForm.fillName(itemName);
 
         // Get the submit button
-        const submitButton = page.locator('button[type="submit"]:has-text("Create Item")');
+        const submitButton = itemForm.saveButton;
 
         // Verify button is enabled initially
         await expect(submitButton).toBeEnabled();
@@ -374,15 +360,11 @@ test.describe('Touch Optimization - User Story 5', () => {
         // Attempt rapid double-click/tap
         await submitButton.click({ clickCount: 2, delay: 50 });
 
-        // Wait for submission to process
-        await page.waitForTimeout(500);
+        await expect(page.getByRole('heading', { name: 'Create New Item' })).not.toBeVisible();
 
         // Check that only ONE item was created (not two)
         // We should see the item in the list only once
-        const itemCount = await page.locator('text=Double Tap Test Item').count();
-
-        // Should be exactly 1 (not 2 or more)
-        expect(itemCount).toBeLessThanOrEqual(1);
+        await expect(page.getByText(itemName, { exact: true })).toHaveCount(1);
 
         // The button should show some processing state
         // (either disabled or with loading indicator)
@@ -398,26 +380,18 @@ test.describe('Touch Optimization - User Story 5', () => {
      * - No janky or stuttering scroll
      */
     test('T053h: Smooth scroll with momentum in long lists', async ({ page }) => {
-        // Set viewport to iPhone size
-        await page.setViewportSize({ width: 375, height: 667 });
-
-        await page.goto('/');
-        await page.waitForSelector('text=Inventory App');
-
         // Create multiple items to ensure scrollable list. Use methods so this test
         // only verifies scrolling behavior, not repeated create-form timing.
         for (let i = 1; i <= 15; i++) {
             await callMeteorMethod<string>(page, 'items.createItem', { name: `Scroll Test Item ${i}` });
         }
         await page.reload();
-        await waitForMeteorReady(page);
+        await expectInventoryReady(page);
         await expect(page.getByText('Scroll Test Item 1', { exact: true })).toBeVisible({ timeout: 5000 });
 
         // Find a scrollable container
         // The -webkit-overflow-scrolling: touch property enables momentum
-        const scrollContainer = page
-            .locator('[data-testid="items-list"]')
-            .or(page.locator('text=Scroll Test Item 1').locator('..').locator('..'));
+        const scrollContainer = getItemsList(page);
 
         // Verify the container has the momentum scrolling CSS property
         const hasWebkitScrolling = await scrollContainer.first().evaluate((el) => {
@@ -433,22 +407,16 @@ test.describe('Touch Optimization - User Story 5', () => {
         expect(hasWebkitScrolling).toBeTruthy();
 
         // Perform a scroll gesture
-        const box = await scrollContainer.first().boundingBox();
-        if (!box) throw new Error('Scroll container not found');
-
+        const box = await requireBoundingBox(scrollContainer, 'Items list');
         const startX = box.x + box.width / 2;
         const startY = box.y + box.height / 2;
 
         // Swipe up to scroll down
-        await page.mouse.move(startX, startY);
-        await page.mouse.down();
-        await page.mouse.move(startX, startY - 200, { steps: 10 });
-        await page.mouse.up();
+        await dragPointer(page, { x: startX, y: startY }, { x: startX, y: startY - 200 });
+        await releasePointer(page);
+        await page.mouse.wheel(0, 400);
 
-        // Wait for scroll to settle
-        await page.waitForTimeout(300);
-
-        // Verify scroll happened by checking if later items are visible
+        // Verify scroll behavior by checking if later items are visible via Playwright auto-waiting.
         await expect(page.getByText('Scroll Test Item 10', { exact: true })).toBeVisible({ timeout: 2000 });
     });
 });

--- a/tests/e2e/helpers/page-objects.ts
+++ b/tests/e2e/helpers/page-objects.ts
@@ -3,7 +3,7 @@
  * Provides reusable methods for interacting with the inventory app UI.
  */
 
-import type { Page, Locator } from '@playwright/test';
+import { expect, type Page, type Locator } from '@playwright/test';
 
 /**
  * Page Object for the main inventory view.
@@ -30,7 +30,7 @@ export class InventoryPage {
      * Get the "Create Item" button locator.
      */
     get addItemButton(): Locator {
-        return this.page.getByRole('button', { name: /create item/i });
+        return this.page.getByRole('main').getByRole('button', { name: /create item/i });
     }
 
     /**
@@ -158,13 +158,20 @@ export class ItemFormPage {
     }
 
     /**
-     * Get the "Is Container" checkbox.
+     * Get the hidden native "Is Container" checkbox input.
      *
-     * NOTE: This uses getByLabel which may not work with Grommet FormField.
-     * If this fails, refactor to use `input[name="isContainer"]` or similar.
+     * Grommet CheckBox renders a hidden native input plus a visible label.
+     * Assert checked state through this input, but use setIsContainer() for interaction.
      */
     get isContainerCheckbox(): Locator {
-        return this.page.getByLabel(/container|location/i);
+        return this.page.locator('input[name="isContainer"]');
+    }
+
+    /**
+     * Get the visible label/touch target for the "Is Container" checkbox.
+     */
+    get isContainerTouchTarget(): Locator {
+        return this.page.getByText('This item is a container (can hold other items)', { exact: true });
     }
 
     /**
@@ -203,6 +210,19 @@ export class ItemFormPage {
     }
 
     /**
+     * Set the "Is Container" checkbox via the visible Grommet label/touch target.
+     */
+    async setIsContainer(isContainer: boolean): Promise<void> {
+        const isCurrentlyChecked = await this.isContainerCheckbox.isChecked();
+
+        if (isCurrentlyChecked !== isContainer) {
+            await this.isContainerTouchTarget.click();
+        }
+
+        await expect(this.isContainerCheckbox).toBeChecked({ checked: isContainer });
+    }
+
+    /**
      * Submit the form using the submit button.
      * Uses Playwright's auto-waiting to ensure button is clickable.
      */
@@ -221,12 +241,8 @@ export class ItemFormPage {
      * if context-specific verification needed.
      */
     async expectSuccess(): Promise<void> {
-        // Default: check that name field is empty (form was cleared after submit)
-        await this.page.waitForTimeout(500); // Brief wait for form to process
-        const nameValue = await this.nameInput.inputValue();
-        if (nameValue !== '') {
-            throw new Error(`Expected form to clear after submission, but name field still contains: "${nameValue}"`);
-        }
+        // Default: check that name field is empty (form was cleared after submit).
+        await expect(this.nameInput).toHaveValue('');
     }
 
     /**
@@ -242,7 +258,7 @@ export class ItemFormPage {
         }
 
         if (data.isContainer) {
-            await this.isContainerCheckbox.check();
+            await this.setIsContainer(true);
         }
     }
 

--- a/tests/e2e/storybook/SearchBar.spec.ts
+++ b/tests/e2e/storybook/SearchBar.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@playwright/test';
+import { gotoStory } from '../helpers/storybook-helpers';
+
+test.describe('SearchBar Component (Storybook)', () => {
+    test.beforeEach(async ({ page }) => {
+        await gotoStory(page, 'ui-searchbar', 'test-interactions');
+    });
+
+    test('should update query and execute search on Enter', async ({ page }) => {
+        const input = page.getByRole('textbox', { name: 'Search query' });
+
+        await input.fill('camp stove');
+        await expect(page.getByTestId('current-query')).toHaveText('camp stove');
+
+        await input.press('Enter');
+
+        await expect(page.getByTestId('last-search')).toHaveText('camp stove');
+        await expect(page.getByTestId('search-count')).toHaveText('1');
+    });
+
+    test('should clear query and invoke clear callback', async ({ page }) => {
+        const input = page.getByRole('textbox', { name: 'Search query' });
+
+        await input.fill('tent stakes');
+        await page.getByRole('button', { name: 'Clear search' }).click();
+
+        await expect(input).toHaveValue('');
+        await expect(page.getByTestId('current-query')).toHaveText('(empty)');
+        await expect(page.getByTestId('clear-count')).toHaveText('1');
+    });
+
+    test('should render scoped mode and keep clear button touch-friendly', async ({ page }) => {
+        await expect(page.getByText('In: Garage')).toBeVisible();
+
+        await page.getByRole('textbox', { name: 'Search query' }).fill('box');
+        const clearButton = page.getByRole('button', { name: 'Clear search' });
+        const box = await clearButton.boundingBox();
+
+        if (box === null) throw new Error('Clear button is not visible');
+        expect(box.width).toBeGreaterThanOrEqual(44);
+        expect(box.height).toBeGreaterThanOrEqual(44);
+    });
+});

--- a/tests/e2e/storybook/TagSelector.spec.ts
+++ b/tests/e2e/storybook/TagSelector.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@playwright/test';
+import { gotoStory } from '../helpers/storybook-helpers';
+
+test.describe('TagSelector Component (Storybook)', () => {
+    test.beforeEach(async ({ page }) => {
+        await gotoStory(page, 'ui-tagselector', 'test-interactions');
+    });
+
+    test('should toggle tag selection and update summary', async ({ page }) => {
+        await expect(page.getByText('1 of 3 tags selected')).toBeVisible();
+
+        await page.getByTestId('tag-touch-target-tag2').click();
+
+        await expect(page.getByText('2 of 3 tags selected')).toBeVisible();
+        await expect(page.getByTestId('last-toggle')).toHaveText('tag2:true');
+
+        await page.getByTestId('tag-touch-target-tag1').click();
+
+        await expect(page.getByText('1 of 3 tags selected')).toBeVisible();
+        await expect(page.getByTestId('last-toggle')).toHaveText('tag1:false');
+    });
+
+    test('should invoke create tag callback', async ({ page }) => {
+        await page.getByRole('button', { name: 'New Tag' }).click();
+
+        await expect(page.getByTestId('create-count')).toHaveText('1');
+    });
+
+    test('should keep tag rows touch-friendly', async ({ page }) => {
+        const box = await page.getByTestId('tag-touch-target-tag3').boundingBox();
+
+        if (box === null) throw new Error('Tag touch target is not visible');
+        expect(box.height).toBeGreaterThanOrEqual(44);
+    });
+});


### PR DESCRIPTION
## Summary
- add Storybook Playwright coverage for `SearchBar` and `TagSelector` (T016)
- add deterministic `TestInteractions` stories to support DOM-visible callback assertions
- fix `TagSelector` so the visible checkbox label area exposes a real 44px touch target
- port proven Storybook interaction/selector patterns into `tests/e2e/app/touch-optimization.spec.ts` (T012b)
- refresh quickstart docs with `SearchBar`/`TagSelector` examples and debugging guidance (T018)
- validate performance: per-story <30s, full E2E <5min, recorded in spec 002 plan (T021)
- fix GitHub Actions Meteor installation to persist `~/.meteor` on PATH
- sync spec 002 artifacts (`tasks.md`, `plan.md`, `storybook-stories-inventory.md`, `test-patterns.md`)

## Included in this PR
- `tests/e2e/storybook/SearchBar.spec.ts`
- `tests/e2e/storybook/TagSelector.spec.ts`
- `tests/e2e/app/touch-optimization.spec.ts`
- `tests/e2e/helpers/page-objects.ts`
- `meteor-app/imports/ui/SearchBar.stories.tsx`
- `meteor-app/imports/ui/TagSelector.stories.tsx`
- `meteor-app/imports/ui/TagSelector.tsx`
- `.github/workflows/node.js.yml`
- spec 002 status / pattern documentation updates

## Validation
- `npx playwright test tests/e2e/storybook --project=storybook-chromium --reporter=line` → 30 passed, 3 skipped
- `npx playwright test tests/e2e/app --project=chromium --reporter=line` → 45 passed
- `npm run test:scripts` → 2 passed
- `npm run check:ci:fresh` → passed (0 errors, existing warnings only)
- CI: all app-test jobs and `Build and deploy` green on Node 22.x / 24.x

## Notes
- Tracked spec 002 backlog (T015, T016, T012b, T018, T021) is complete.
- Detailed task status is recorded in `specs/002-storybook-e2e-testing/tasks.md`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author