### PR TITLE
[codex] Add design system foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ The app will be available at http://localhost:3000/.
 
 ## Features
 
+### Design System
+
+The app uses a lightweight design language for touch-friendly inventory workflows. See [`docs/DESIGN_SYSTEM.md`](docs/DESIGN_SYSTEM.md) for product feel, shared tokens, component standards, and the feature design requirements template.
+
 ### URL Routing
 
 The app uses client-side URL routing (via [Wouter](https://github.com/molefrog/wouter)) for navigation:

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -1,0 +1,155 @@
+# Design System
+
+This document is the product design baseline for the inventory app. It should stay practical: enough structure to keep new features consistent, not a separate design-system project.
+
+## Product Feel
+
+The app is a household operations tool. It should feel calm, quick, and touch-ready, with enough density for repeated inventory work.
+
+- Prioritize scanning, comparison, and repeated action over decorative presentation.
+- Keep the first screen of a workflow useful; avoid marketing-style hero layouts.
+- Make state obvious: selected scope, active filters, item location, destructive actions, loading, and empty results.
+- Optimize for iPhone and iPad touch use first, while keeping desktop efficient.
+- Prefer predictable controls over clever custom interactions.
+
+## Source Of Truth
+
+Shared tokens live in `meteor-app/imports/ui/theme.ts`.
+
+- `uiTokens` is the TypeScript source for component styles.
+- `uiTokenCssVariables` mirrors core tokens into CSS custom properties for global CSS.
+- `DesignSystemGlobalStyle` installs the CSS variables and base focus/body styles.
+- `theme` adapts the tokens into the Grommet theme.
+
+When adding or changing visual values, prefer updating `uiTokens` first and consuming the token from components.
+
+## Tokens
+
+### Color
+
+- `brand`: primary app actions, active navigation, selected filters, links that move the user through app structure.
+- `danger`: destructive actions such as delete, clear, irreversible import choices, and destructive confirmations.
+- `success`: completed work, valid imports, available/healthy states.
+- `warning`: recoverable problems, skipped import rows, missing attachments, or choices needing review.
+- `text`, `textWeak`, `textMuted`, `textInverse`: hierarchy for content, secondary metadata, placeholder/empty text, and text on strong color.
+- `surfaceRaised`, `surface`, `surfaceSubtle`, `surfaceSunken`: page backgrounds, list rows, panels, and low-emphasis controls.
+- `border`, `borderSubtle`, `borderStrong`: dividers, cards, table rules, and selected/structured boundaries.
+
+Use color to encode meaning, not decoration. A status color should answer "what state is this in?" or "how risky is this action?"
+
+### Size And Spacing
+
+- `size.touchTarget` is the minimum interactive target: 44px.
+- Use `space` tokens for gaps and padding instead of one-off pixel values.
+- Use stable dimensions for repeated controls, nav tabs, chips, rows, and icon buttons so hover/active/loading states do not shift layout.
+
+### Radius And Shadow
+
+- `radius.control` is the default for buttons, inputs, chips with text, and compact panels.
+- `radius.small` is for small embedded elements.
+- `radius.pill` is for badges and chips.
+- Shadows should communicate layering or interactivity. Avoid decorative floating sections.
+
+### Type
+
+- Use the system font stack from `uiTokens.font.family`.
+- Keep app chrome and repeated UI compact. Reserve large text for page titles or major empty states.
+- Use `textWeak` and `textMuted` before shrinking text too far.
+
+### Motion And Focus
+
+- Use `motion.fast` for button feedback and `motion.standard` for overlays or view transitions.
+- All keyboard-visible focus should use the shared focus ring.
+- Touch feedback should be visible but subtle.
+
+## Component Standards
+
+### Buttons
+
+- Use Grommet `Button` for standard app chrome and form actions.
+- Use `TouchButton` when custom pressed-state feedback is needed.
+- Use icon buttons for common tool actions when the icon is familiar.
+- Destructive buttons must use `danger` styling and be paired with confirmation when data can be lost.
+- Disabled buttons should not be the only explanation of an unavailable action.
+
+### Inputs And Forms
+
+- Inputs must preserve the 44px touch target.
+- Put required fields first and keep optional inventory metadata grouped.
+- Show validation close to the field that caused it.
+- Prevent double submit while async work is pending.
+
+### Lists, Tables, And Cards
+
+- Inventory browsing should favor list/table density over decorative cards.
+- Use cards only for repeated item summaries, modal content, or genuinely framed tools.
+- Item rows and cards should show name, container/location context when relevant, tags or key metadata, and the primary action affordance.
+- Empty states should say what is empty and provide the next useful action when one exists.
+
+### Chips And Badges
+
+- Tags use chips.
+- Filters use strong selected chips with explicit removal controls.
+- Status badges should use semantic colors and short labels.
+- Chip remove targets must remain at least 44px.
+
+### Navigation
+
+- Desktop navigation can use compact icon-plus-text buttons.
+- Mobile primary navigation is fixed to the bottom and uses the shared touch target.
+- Active navigation state must be visually distinct and expose `aria-current="page"`.
+
+### Dialogs And Destructive Flows
+
+- Dialogs should focus the decision, not restate the whole screen.
+- Destructive dialogs must name the affected object and consequences.
+- Multi-outcome destructive flows, such as deleting a container with contents, should present each outcome as a distinct choice.
+
+### Loading, Empty, And Error States
+
+- Loading states should appear near the area being loaded unless the whole app is blocked.
+- Use overlays only for blocking work.
+- Error states should include the failing action and a recovery path when available.
+- Import/export flows should distinguish success, warning, and failure clearly.
+
+## Feature Design Requirements
+
+Feature specs should include a small design section after functional requirements. Use this template when a feature changes UI:
+
+```markdown
+### Design Requirements
+
+- Primary workflow:
+- Entry points:
+- Layout:
+- Component patterns:
+- States:
+- Touch/mobile behavior:
+- Accessibility:
+- Empty/loading/error behavior:
+- Destructive or irreversible actions:
+- Storybook coverage:
+- E2E/visual checks:
+```
+
+Good design requirements are concrete enough to test. For example:
+
+- "The clear-all filters action uses danger styling and remains at least 44px high."
+- "On mobile, the submit action stays visible after the keyboard opens."
+- "The import summary separates imported, skipped, and failed records with semantic status colors."
+
+## Adding New UI
+
+1. Check for an existing component or pattern in `meteor-app/imports/ui`.
+2. Use `uiTokens` for visual values.
+3. Add or update a Storybook story for reusable components.
+4. Add E2E coverage when the interaction crosses routing, Meteor methods, or persisted data.
+5. Update this document when a new reusable pattern appears.
+
+## Migration Notes
+
+Current known migration opportunities:
+
+- Continue moving hardcoded colors, radii, spacing, and touch sizes in search, breadcrumb, tag, and list components onto `uiTokens`.
+- Replace remaining emoji or text-only tool affordances with Grommet icons where a familiar icon exists.
+- Keep CSS custom properties in `uiTokenCssVariables` limited to values used by global CSS; component-level styles should import `uiTokens` directly.

--- a/meteor-app/client/main.css
+++ b/meteor-app/client/main.css
@@ -11,5 +11,5 @@ body,
 
 body {
     padding: 0;
-    font-family: sans-serif;
+    font-family: var(--inventory-font-family);
 }

--- a/meteor-app/imports/ui/AllTagsView/AllTagsViewPresentation.tsx
+++ b/meteor-app/imports/ui/AllTagsView/AllTagsViewPresentation.tsx
@@ -1,10 +1,12 @@
+import { Button } from 'grommet';
+import { Add } from 'grommet-icons';
 import React, { type ComponentProps, type ReactElement, useState } from 'react';
 import styled from 'styled-components';
 
 import type { TagRecord } from '/imports/model/TagRecord';
 import { CreateTagDialog } from '/imports/ui/CreateTagDialog';
 import { LongPressContextMenu } from '/imports/ui/LongPressContextMenu';
-import StyledButton from '/imports/ui/StyledButton';
+import { uiTokens } from '/imports/ui/theme';
 
 /**
  * AllTagsViewPresentation is a pure presentation component that displays tags
@@ -181,33 +183,31 @@ const TagList = styled(
                             )}
                         </label>
                         <span className="tag-actions-container">
-                            <StyledButton
+                            <Button
+                                a11yTitle="Add child tag"
                                 className="new-child-action"
+                                icon={<Add size="small" />}
                                 onClick={(event) => {
                                     event.stopPropagation();
                                     handleAddChild();
                                 }}
-                            >
-                                +
-                            </StyledButton>
-                            <StyledButton
+                            />
+                            <Button
                                 className="rename-tag-action"
+                                label="Rename"
                                 onClick={(event) => {
                                     event.stopPropagation();
                                     handleRename();
                                 }}
-                            >
-                                Rename
-                            </StyledButton>
-                            <StyledButton
+                            />
+                            <Button
                                 className="remove-tag-action"
+                                label="Delete"
                                 onClick={(event) => {
                                     event.stopPropagation();
                                     handleDelete();
                                 }}
-                            >
-                                Delete
-                            </StyledButton>
+                            />
                         </span>
                     </div>
                 </LongPressContextMenu>
@@ -289,12 +289,12 @@ const DetachedTagsView = styled(
                           } detached tags out of ${totalTagsCount} (updated ${lastUpdated.toLocaleString()})`}
                 </div>
                 <div>
-                    <StyledButton disabled={isUpdating} onClick={onCheck}>
-                        Check
-                    </StyledButton>
-                    <StyledButton disabled={isUpdating || detachedTagIds.length === 0} onClick={onRemoveAll}>
-                        Remove All
-                    </StyledButton>
+                    <Button disabled={isUpdating} label="Check" onClick={onCheck} />
+                    <Button
+                        disabled={isUpdating || detachedTagIds.length === 0}
+                        label="Remove All"
+                        onClick={onRemoveAll}
+                    />
                 </div>
             </div>
         );
@@ -418,9 +418,9 @@ export const AllTagsViewPresentation = styled(
             </div>
         );
     }
-)`;
+)`
     ${TagList} {
-        // Renaming and removing actions don't apply to root tag.
+        /* Renaming and removing actions don't apply to root tag. */
         .tag-body[data-tag-id=''] {
             .rename-tag-action,
             .remove-tag-action {
@@ -434,7 +434,7 @@ export const AllTagsViewPresentation = styled(
             line-height: 1.5em;
 
             .tag-item-count {
-                color: #666;
+                color: ${uiTokens.color.textWeak};
                 font-size: 0.85em;
                 font-weight: normal;
             }
@@ -459,7 +459,7 @@ export const AllTagsViewPresentation = styled(
             padding-inline-end: 1em;
 
             &:hover {
-                background-color: #cccccc;
+                background-color: ${uiTokens.color.surfaceHover};
             }
         }
 

--- a/meteor-app/imports/ui/App.tsx
+++ b/meteor-app/imports/ui/App.tsx
@@ -24,62 +24,9 @@ import { SearchFragmentBuilder } from './SearchFragmentBuilder';
 import { SearchResultsView } from './SearchResultsView';
 import { SearchScopeSelector } from './SearchScopeSelector';
 import { SettingsDataView } from './SettingsDataView';
+import { DesignSystemGlobalStyle, theme, uiTokens } from './theme';
 
-// Grommet theme with iOS-style design and touch-friendly sizing
-const theme = {
-    global: {
-        colors: {
-            brand: '#007aff', // iOS blue
-            focus: '#007aff',
-        },
-        font: {
-            family: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-            size: '16px',
-        },
-        control: {
-            border: {
-                radius: '8px',
-            },
-        },
-    },
-    button: {
-        default: {
-            // Ensure all buttons meet 44px minimum touch target
-            padding: {
-                vertical: '10px', // 10px + 16px font + 10px = 36px + border ≈ 44px total
-                horizontal: '20px',
-            },
-        },
-        border: {
-            radius: '8px',
-        },
-    },
-    formField: {
-        border: false,
-        content: {
-            pad: { vertical: 'small' },
-        },
-    },
-    textInput: {
-        extend: `
-            min-height: 44px;
-            padding: 12px 16px;
-        `,
-    },
-    textArea: {
-        extend: `
-            min-height: 44px;
-            padding: 12px 16px;
-        `,
-    },
-    select: {
-        container: {
-            extend: `
-                min-height: 44px;
-            `,
-        },
-    },
-};
+const navigationButtonStyle: React.CSSProperties = { minHeight: uiTokens.size.touchTarget };
 
 export const App = (): ReactElement => {
     const [location] = useLocation();
@@ -212,6 +159,7 @@ export const App = (): ReactElement => {
 
     return (
         <Grommet theme={theme} full>
+            <DesignSystemGlobalStyle />
             <Box fill>
                 {/* Header with navigation */}
                 <Header background="brand" pad="small">
@@ -225,7 +173,7 @@ export const App = (): ReactElement => {
                                 label="Items"
                                 primary={location === '/items' || location === '/'}
                                 plain={location !== '/items' && location !== '/'}
-                                style={{ minHeight: '44px' }}
+                                style={navigationButtonStyle}
                             />
                         </Link>
                         <Link href="/tags">
@@ -234,7 +182,7 @@ export const App = (): ReactElement => {
                                 label="Tags"
                                 primary={location === '/tags'}
                                 plain={location !== '/tags'}
-                                style={{ minHeight: '44px' }}
+                                style={navigationButtonStyle}
                             />
                         </Link>
                         <Link href="/search">
@@ -243,7 +191,7 @@ export const App = (): ReactElement => {
                                 label="Search"
                                 primary={location === '/search'}
                                 plain={location !== '/search'}
-                                style={{ minHeight: '44px' }}
+                                style={navigationButtonStyle}
                             />
                         </Link>
                         <Link href="/settings/data">
@@ -252,7 +200,7 @@ export const App = (): ReactElement => {
                                 label="Data"
                                 primary={location === '/settings/data'}
                                 plain={location !== '/settings/data'}
-                                style={{ minHeight: '44px' }}
+                                style={navigationButtonStyle}
                             />
                         </Link>
                     </Nav>

--- a/meteor-app/imports/ui/FilterBar.tsx
+++ b/meteor-app/imports/ui/FilterBar.tsx
@@ -1,7 +1,9 @@
+import { Close } from 'grommet-icons';
 import React, { type ComponentProps } from 'react';
 import styled from 'styled-components';
 
 import type { SearchFragment } from '/imports/model/SearchFragment';
+import { uiTokens } from '/imports/ui/theme';
 
 /**
  * FilterBar component for context-aware filtering of current view.
@@ -39,44 +41,44 @@ interface FilterBarProps extends Omit<ComponentProps<'div'>, 'onChange'> {
 const Container = styled.div`
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: ${uiTokens.space.sm};
 `;
 
 const FilterBarHeader = styled.div`
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 12px;
+    gap: ${uiTokens.space.md};
 `;
 
 const FilterCount = styled.span`
-    font-size: 14px;
-    font-weight: 600;
-    color: #666;
+    font-size: ${uiTokens.font.sizeSmall};
+    font-weight: ${uiTokens.font.weightSemibold};
+    color: ${uiTokens.color.textWeak};
 `;
 
 const ClearAllButton = styled.button`
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 6px;
-    min-height: 44px;
-    padding: 8px 16px;
+    gap: ${uiTokens.space.sm};
+    min-height: ${uiTokens.size.touchTarget};
+    padding: ${uiTokens.space.sm} ${uiTokens.space.lg};
     background: transparent;
-    color: #ff3b30;
-    border: 1px solid #ff3b30;
-    border-radius: 8px;
-    font-size: 14px;
-    font-weight: 600;
+    color: ${uiTokens.color.danger};
+    border: 1px solid ${uiTokens.color.danger};
+    border-radius: ${uiTokens.radius.control};
+    font-size: ${uiTokens.font.sizeSmall};
+    font-weight: ${uiTokens.font.weightSemibold};
     cursor: pointer;
-    transition: all 0.15s;
+    transition: background-color ${uiTokens.motion.fast}, transform ${uiTokens.motion.fast};
 
     &:hover {
-        background: rgba(255, 59, 48, 0.1);
+        background: ${uiTokens.color.dangerSubtle};
     }
 
     &:active {
-        background: rgba(255, 59, 48, 0.2);
+        background: ${uiTokens.color.dangerSubtleStrong};
         transform: scale(0.98);
     }
 `;
@@ -84,61 +86,61 @@ const ClearAllButton = styled.button`
 const FilterChipList = styled.div`
     display: flex;
     flex-wrap: wrap;
-    gap: 8px;
+    gap: ${uiTokens.space.sm};
 `;
 
 const FilterChip = styled.div`
     display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 8px 12px;
-    background: #007aff;
-    color: white;
-    border-radius: 20px;
-    min-height: 44px;
+    gap: ${uiTokens.space.sm};
+    padding: ${uiTokens.space.sm} ${uiTokens.space.md};
+    background: ${uiTokens.color.brand};
+    color: ${uiTokens.color.textInverse};
+    border-radius: ${uiTokens.radius.pill};
+    min-height: ${uiTokens.size.touchTarget};
 `;
 
 const FilterType = styled.span`
-    font-size: 12px;
-    font-weight: 600;
+    font-size: ${uiTokens.font.sizeXSmall};
+    font-weight: ${uiTokens.font.weightSemibold};
     text-transform: uppercase;
     opacity: 0.8;
 `;
 
 const FilterValue = styled.span`
-    font-size: 14px;
-    font-weight: 500;
+    font-size: ${uiTokens.font.sizeSmall};
+    font-weight: ${uiTokens.font.weightMedium};
 `;
 
 const RemoveButton = styled.button`
     display: flex;
     align-items: center;
     justify-content: center;
-    min-width: 44px;
-    min-height: 44px;
-    padding: 10px; /* Centers 24px icon: (44px - 24px) / 2 = 10px */
-    background: rgba(255, 255, 255, 0.2);
+    min-width: ${uiTokens.size.touchTarget};
+    min-height: ${uiTokens.size.touchTarget};
+    padding: ${uiTokens.space.sm};
+    background: ${uiTokens.color.textInverseWeak};
     border: none;
-    border-radius: 50%;
+    border-radius: ${uiTokens.radius.round};
     cursor: pointer;
-    color: white;
-    font-size: 16px;
-    transition: background-color 0.15s;
+    color: ${uiTokens.color.textInverse};
+    font-size: ${uiTokens.font.sizeMedium};
+    transition: background-color ${uiTokens.motion.fast};
 
     &:hover {
-        background: rgba(255, 255, 255, 0.3);
+        background: ${uiTokens.color.textInverseWeakHover};
     }
 
     &:active {
-        background: rgba(255, 255, 255, 0.4);
+        background: ${uiTokens.color.textInverseWeakActive};
     }
 `;
 
 const EmptyState = styled.div`
-    padding: 12px;
+    padding: ${uiTokens.space.md};
     text-align: center;
-    color: #999;
-    font-size: 14px;
+    color: ${uiTokens.color.textMuted};
+    font-size: ${uiTokens.font.sizeSmall};
 `;
 
 export const FilterBar: React.FC<FilterBarProps> = ({
@@ -221,7 +223,7 @@ export const FilterBar: React.FC<FilterBarProps> = ({
                                         aria-label={`Remove ${display.type} filter`}
                                         type="button"
                                     >
-                                        ✕
+                                        <Close size="16px" />
                                     </RemoveButton>
                                 </FilterChip>
                             );

--- a/meteor-app/imports/ui/ItemsByTagView/ItemsByTagViewPresentation.tsx
+++ b/meteor-app/imports/ui/ItemsByTagView/ItemsByTagViewPresentation.tsx
@@ -1,9 +1,11 @@
+import { Button } from 'grommet';
+import { Apps } from 'grommet-icons';
 import React, { type ComponentProps, type ReactElement } from 'react';
 import styled from 'styled-components';
 
 import type { InventoryItem } from '/imports/model/InventoryItem';
 import type { TagRecord } from '/imports/model/TagRecord';
-import StyledButton from '/imports/ui/StyledButton';
+import { uiTokens } from '/imports/ui/theme';
 import { DESCRIPTION_PREVIEW_LENGTH } from '/imports/utility/constants';
 
 /**
@@ -49,7 +51,7 @@ const ItemCard = styled(
             <div {...rootElementProps} onClick={handleClick} data-item-id={item._id}>
                 <div className="item-card-header">
                     <h3 className="item-name">{item.name}</h3>
-                    {item.isContainer && <span className="container-badge">📁</span>}
+                    {item.isContainer && <Apps className="container-badge" size="18px" />}
                 </div>
                 {typeof item.description === 'string' && item.description !== '' && (
                     <p className="item-description">
@@ -64,14 +66,14 @@ const ItemCard = styled(
         );
     }
 )`
-    border: 1px solid #ddd;
-    border-radius: 8px;
+    border: 1px solid ${uiTokens.color.border};
+    border-radius: ${uiTokens.radius.control};
     padding: 1em;
     cursor: ${(props) => (props.onSelectItem !== undefined ? 'pointer' : 'default')};
     transition: background-color 0.2s, box-shadow 0.2s;
 
     &:hover {
-        background-color: ${(props) => (props.onSelectItem !== undefined ? '#f5f5f5' : 'transparent')};
+        background-color: ${(props) => (props.onSelectItem !== undefined ? uiTokens.color.surface : 'transparent')};
         box-shadow: ${(props) => (props.onSelectItem !== undefined ? '0 2px 4px rgba(0,0,0,0.1)' : 'none')};
     }
 
@@ -89,12 +91,12 @@ const ItemCard = styled(
     }
 
     .container-badge {
-        font-size: 1.2em;
+        color: ${uiTokens.color.brand};
     }
 
     .item-description {
         margin: 0.5em 0;
-        color: #666;
+        color: ${uiTokens.color.textWeak};
         font-size: 0.9em;
         line-height: 1.4;
     }
@@ -102,7 +104,7 @@ const ItemCard = styled(
     .item-location {
         margin-top: 0.5em;
         font-size: 0.85em;
-        color: #888;
+        color: ${uiTokens.color.textMuted};
     }
 
     .location-label {
@@ -180,9 +182,7 @@ export const ItemsByTagViewPresentation = styled(
                         </p>
                     </div>
                     {onClearSelection !== undefined && (
-                        <StyledButton className="clear-button" onClick={onClearSelection}>
-                            Clear Selection
-                        </StyledButton>
+                        <Button className="clear-button" secondary label="Clear Selection" onClick={onClearSelection} />
                     )}
                 </div>
 
@@ -212,7 +212,7 @@ export const ItemsByTagViewPresentation = styled(
         align-items: flex-start;
         margin-bottom: 1.5em;
         padding-bottom: 1em;
-        border-bottom: 2px solid #ddd;
+        border-bottom: 2px solid ${uiTokens.color.border};
     }
 
     .tag-info {
@@ -227,7 +227,7 @@ export const ItemsByTagViewPresentation = styled(
 
     .item-count {
         margin: 0;
-        color: #666;
+        color: ${uiTokens.color.textWeak};
         font-size: 0.9em;
     }
 
@@ -245,12 +245,12 @@ export const ItemsByTagViewPresentation = styled(
     .loading-state {
         text-align: center;
         padding: 3em;
-        color: #999;
+        color: ${uiTokens.color.textMuted};
         font-size: 1.1em;
     }
 
     .loading-state {
-        color: #666;
+        color: ${uiTokens.color.textWeak};
     }
 
     ${ItemCard} {

--- a/meteor-app/imports/ui/LoadingSpinner.tsx
+++ b/meteor-app/imports/ui/LoadingSpinner.tsx
@@ -2,6 +2,8 @@ import { Box, Text } from 'grommet';
 import React, { type ReactElement } from 'react';
 import styled, { keyframes } from 'styled-components';
 
+import { uiTokens } from './theme';
+
 /**
  * LoadingSpinner component optimized for mobile touch interfaces.
  *
@@ -79,10 +81,11 @@ const getSizePx = (size: LoadingSpinnerSize): number => {
 const SpinnerCircle = styled.div<SpinnerCircleProps>`
     width: ${(props) => getSizePx(props.$size)}px;
     height: ${(props) => getSizePx(props.$size)}px;
-    border: ${(props) =>
-        Math.max(MIN_BORDER_WIDTH_PX, getSizePx(props.$size) / BORDER_WIDTH_DIVISOR)}px solid rgba(0, 0, 0, 0.1);
+    border-style: solid;
+    border-width: ${(props) => Math.max(MIN_BORDER_WIDTH_PX, getSizePx(props.$size) / BORDER_WIDTH_DIVISOR)}px;
+    border-color: ${uiTokens.color.scrim};
     border-top-color: ${(props) => props.$color};
-    border-radius: 50%;
+    border-radius: ${uiTokens.radius.round};
     animation: ${spin} 0.8s linear infinite;
     will-change: transform;
 `;
@@ -91,7 +94,7 @@ const SpinnerContainer = styled(Box)`
     display: inline-flex;
     flex-direction: column;
     align-items: center;
-    gap: 12px;
+    gap: ${uiTokens.space.md};
 `;
 
 const OverlayBackdrop = styled.div`
@@ -100,13 +103,13 @@ const OverlayBackdrop = styled.div`
     left: 0;
     right: 0;
     bottom: 0;
-    background: rgba(255, 255, 255, 0.95);
+    background: ${uiTokens.color.overlayLight};
     backdrop-filter: blur(10px);
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 9999;
-    animation: fadeIn 0.2s ease-out;
+    z-index: ${uiTokens.zIndex.overlay};
+    animation: fadeIn ${uiTokens.motion.standard};
 
     @keyframes fadeIn {
         from {
@@ -127,7 +130,7 @@ const OverlayBackdrop = styled.div`
 export const LoadingSpinner = ({
     size = 'medium',
     text,
-    color = '#007aff',
+    color = uiTokens.color.brand,
     overlay = false,
     ariaLabel = 'Loading',
 }: LoadingSpinnerProps): ReactElement => {
@@ -137,7 +140,7 @@ export const LoadingSpinner = ({
             {text !== undefined && (
                 <Text
                     size={size === 'small' ? 'small' : 'medium'}
-                    color="dark-4"
+                    color={uiTokens.color.textWeak}
                     textAlign="center"
                     style={{ maxWidth: '250px' }}
                 >

--- a/meteor-app/imports/ui/README.md
+++ b/meteor-app/imports/ui/README.md
@@ -2,6 +2,22 @@
 
 This directory contains React components for the inventory management application, with URL-based routing using Wouter.
 
+## Design System Foundation
+
+-   App-level Grommet theme and shared UI tokens live in `theme.ts`.
+-   Design principles, token meanings, component standards, and feature design requirement prompts live in
+    `/docs/DESIGN_SYSTEM.md`.
+-   Prefer Grommet `Button` for standard actions and `TouchButton` when custom pressed-state feedback is needed.
+-   `StyledButton` is deprecated and should not be used in new code.
+
+### Remaining Migration Opportunities
+
+-   Move remaining hardcoded colors, radii, and touch-target sizes in `SearchBar`, `SearchResultsView`,
+    `SearchFragmentBuilder`, `BreadcrumbTrail`, `LongPressContextMenu`, and related stories onto `uiTokens`.
+-   Replace remaining emoji UI icons in focused component passes. Search-related components were intentionally left
+    alone during the design-system foundation cleanup to avoid conflicts with parallel search work.
+-   Consider a `styled-components` theme provider bridge once most shared components consume tokens consistently.
+
 ## URL Routing Patterns
 
 The application uses **Wouter v3** for client-side routing. All navigation is URL-driven.

--- a/meteor-app/imports/ui/StyledButton.tsx
+++ b/meteor-app/imports/ui/StyledButton.tsx
@@ -1,5 +1,8 @@
 import styled from 'styled-components';
 
+/**
+ * @deprecated Prefer Grommet Button for app chrome and ui/TouchButton for custom touch feedback.
+ */
 export default styled.button`
     opacity: 0.8;
 `;

--- a/meteor-app/imports/ui/TagChip.tsx
+++ b/meteor-app/imports/ui/TagChip.tsx
@@ -2,6 +2,8 @@ import { Box, Button, type BoxProps } from 'grommet';
 import { Close } from 'grommet-icons';
 import React, { type ReactElement } from 'react';
 
+import { uiTokens } from './theme';
+
 export interface TagChipProps extends Omit<BoxProps, 'onClick'> {
     /** The name of the tag to display */
     tagName: string;
@@ -32,32 +34,32 @@ export function TagChip({
         <Box
             direction="row"
             align="center"
-            background={disabled ? 'light-4' : { color, opacity: 'weak' }}
+            background={disabled ? uiTokens.color.surfaceSubtle : { color, opacity: 'weak' }}
             pad={{ horizontal: 'small', vertical: 'xsmall' }}
-            round="medium"
+            round={uiTokens.radius.pill}
             gap="xsmall"
             {...boxProps}
         >
             <Box
                 as="span"
                 style={{
-                    fontSize: '14px',
-                    fontWeight: 500,
-                    color: disabled ? '#999' : '#333',
+                    fontSize: uiTokens.font.sizeSmall,
+                    fontWeight: uiTokens.font.weightMedium,
+                    color: disabled ? uiTokens.color.textMuted : uiTokens.color.text,
                 }}
             >
                 {tagName}
             </Box>
             {onRemove !== undefined && (
                 <Button
-                    icon={<Close size="small" color={disabled ? 'light-6' : 'dark-3'} />}
+                    icon={<Close size="small" color={disabled ? uiTokens.color.textMuted : uiTokens.color.textWeak} />}
                     onClick={onRemove}
                     disabled={disabled}
                     plain
                     style={{
-                        minWidth: '44px',
-                        minHeight: '44px',
-                        padding: '12px',
+                        minWidth: uiTokens.size.touchTarget,
+                        minHeight: uiTokens.size.touchTarget,
+                        padding: uiTokens.space.md,
                     }}
                     aria-label={`Remove ${tagName} tag`}
                 />

--- a/meteor-app/imports/ui/TouchButton.tsx
+++ b/meteor-app/imports/ui/TouchButton.tsx
@@ -1,6 +1,8 @@
 import React, { type ComponentProps, type ReactElement, useState, useCallback } from 'react';
 import styled from 'styled-components';
 
+import { uiTokens } from './theme';
+
 /**
  * TouchButton component providing iOS-style visual feedback for touch interactions.
  *
@@ -49,36 +51,37 @@ const StyledButton = styled.button<StyledButtonProps>`
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 8px;
-    min-height: 44px;
-    min-width: 44px;
-    padding: 12px 20px;
+    gap: ${uiTokens.space.sm};
+    min-height: ${uiTokens.size.touchTarget};
+    min-width: ${uiTokens.size.touchTarget};
+    padding: ${uiTokens.space.md} ${uiTokens.space.xl};
     border: none;
-    border-radius: 8px;
-    font-size: 16px;
-    font-weight: 600;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    border-radius: ${uiTokens.radius.control};
+    font-size: ${uiTokens.font.size};
+    font-weight: ${uiTokens.font.weightSemibold};
+    font-family: ${uiTokens.font.family};
     cursor: pointer;
     user-select: none;
-    transition: all 0.15s ease-out;
+    transition: background-color ${uiTokens.motion.fast}, box-shadow ${uiTokens.motion.fast},
+        transform ${uiTokens.motion.fast}, opacity ${uiTokens.motion.fast};
     width: ${(props) => (props.$fullWidth ? '100%' : 'auto')};
 
     /* Variant: Primary */
     ${(props) =>
         props.$variant === 'primary' &&
         `
-        background: #007aff;
-        color: white;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+        background: ${uiTokens.color.brand};
+        color: ${uiTokens.color.white};
+        box-shadow: ${uiTokens.shadow.raised};
 
         &:hover:not(:disabled) {
-            background: #0051d5;
-            box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+            background: ${uiTokens.color.brandHover};
+            box-shadow: ${uiTokens.shadow.raisedHover};
         }
 
         &:active:not(:disabled), &.pressed {
-            background: #004bb8;
-            box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+            background: ${uiTokens.color.brandActive};
+            box-shadow: ${uiTokens.shadow.pressed};
             transform: scale(0.98);
         }
     `}
@@ -87,16 +90,16 @@ const StyledButton = styled.button<StyledButtonProps>`
     ${(props) =>
         props.$variant === 'secondary' &&
         `
-        background: #f2f2f7;
-        color: #007aff;
+        background: ${uiTokens.color.surfaceSubtle};
+        color: ${uiTokens.color.brand};
         box-shadow: none;
 
         &:hover:not(:disabled) {
-            background: #e5e5ea;
+            background: ${uiTokens.color.surfaceSubtleHover};
         }
 
         &:active:not(:disabled), &.pressed {
-            background: #d1d1d6;
+            background: ${uiTokens.color.surfaceSubtleActive};
             transform: scale(0.98);
         }
     `}
@@ -105,18 +108,18 @@ const StyledButton = styled.button<StyledButtonProps>`
     ${(props) =>
         props.$variant === 'danger' &&
         `
-        background: #ff3b30;
-        color: white;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+        background: ${uiTokens.color.danger};
+        color: ${uiTokens.color.white};
+        box-shadow: ${uiTokens.shadow.raised};
 
         &:hover:not(:disabled) {
-            background: #e60000;
-            box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+            background: ${uiTokens.color.dangerHover};
+            box-shadow: ${uiTokens.shadow.raisedHover};
         }
 
         &:active:not(:disabled), &.pressed {
-            background: #cc0000;
-            box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+            background: ${uiTokens.color.dangerActive};
+            box-shadow: ${uiTokens.shadow.pressed};
             transform: scale(0.98);
         }
     `}
@@ -126,15 +129,15 @@ const StyledButton = styled.button<StyledButtonProps>`
         props.$variant === 'ghost' &&
         `
         background: transparent;
-        color: #007aff;
+        color: ${uiTokens.color.brand};
         box-shadow: none;
 
         &:hover:not(:disabled) {
-            background: rgba(0, 122, 255, 0.08);
+            background: ${uiTokens.color.brandGhostHover};
         }
 
         &:active:not(:disabled), &.pressed {
-            background: rgba(0, 122, 255, 0.15);
+            background: ${uiTokens.color.brandGhostActive};
             transform: scale(0.98);
         }
     `}
@@ -157,7 +160,7 @@ const IconWrapper = styled.span`
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-size: 20px;
+    font-size: ${uiTokens.font.sizeLarge};
 `;
 
 const LoadingSpinner = styled.span`
@@ -166,7 +169,7 @@ const LoadingSpinner = styled.span`
     height: 16px;
     border: 2px solid currentColor;
     border-top-color: transparent;
-    border-radius: 50%;
+    border-radius: ${uiTokens.radius.round};
     animation: spin 0.6s linear infinite;
 
     @keyframes spin {

--- a/meteor-app/imports/ui/theme.ts
+++ b/meteor-app/imports/ui/theme.ts
@@ -1,0 +1,213 @@
+import { createGlobalStyle } from 'styled-components';
+
+export const uiTokens = {
+    color: {
+        canvas: '#ffffff',
+        brand: '#007aff',
+        brandHover: '#0051d5',
+        brandActive: '#004bb8',
+        brandSubtle: 'rgba(0, 122, 255, 0.1)',
+        brandGhostHover: 'rgba(0, 122, 255, 0.08)',
+        brandGhostActive: 'rgba(0, 122, 255, 0.15)',
+        danger: '#ff3b30',
+        dangerHover: '#e60000',
+        dangerActive: '#cc0000',
+        dangerSubtle: 'rgba(255, 59, 48, 0.1)',
+        dangerSubtleStrong: 'rgba(255, 59, 48, 0.2)',
+        success: '#34c759',
+        successSubtle: '#e8f5e9',
+        warning: '#ff9500',
+        warningSubtle: '#fff3cd',
+        warningText: '#856404',
+        info: '#4a90e2',
+        text: '#333333',
+        textWeak: '#666666',
+        textMuted: '#999999',
+        textInverse: '#ffffff',
+        textInverseWeak: 'rgba(255, 255, 255, 0.2)',
+        textInverseWeakHover: 'rgba(255, 255, 255, 0.3)',
+        textInverseWeakActive: 'rgba(255, 255, 255, 0.4)',
+        border: '#dddddd',
+        borderSubtle: '#eeeeee',
+        borderStrong: '#d9dde4',
+        surface: '#f5f5f5',
+        surfaceRaised: '#ffffff',
+        surfaceSunken: '#f7f8fa',
+        surfaceSubtle: '#f2f2f7',
+        surfaceSubtleHover: '#e5e5ea',
+        surfaceSubtleActive: '#d1d1d6',
+        surfaceHover: '#cccccc',
+        overlayLight: 'rgba(255, 255, 255, 0.95)',
+        scrimWeak: 'rgba(0, 0, 0, 0.05)',
+        scrim: 'rgba(0, 0, 0, 0.1)',
+        white: '#ffffff',
+    },
+    radius: {
+        control: '8px',
+        small: '4px',
+        pill: '999px',
+        round: '50%',
+    },
+    size: {
+        touchTarget: '44px',
+        mobileNav: '72px',
+    },
+    space: {
+        none: '0',
+        xxs: '2px',
+        xs: '4px',
+        sm: '8px',
+        md: '12px',
+        lg: '16px',
+        xl: '20px',
+        xxl: '24px',
+        xxxl: '32px',
+        page: '16px',
+    },
+    font: {
+        family: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+        size: '16px',
+        sizeXSmall: '12px',
+        sizeSmall: '14px',
+        sizeMedium: '16px',
+        sizeLarge: '20px',
+        sizeTitle: '24px',
+        weightRegular: 400,
+        weightMedium: 500,
+        weightSemibold: 600,
+        lineHeightTight: 1.2,
+        lineHeightBody: 1.4,
+    },
+    shadow: {
+        raised: '0 1px 3px rgba(0, 0, 0, 0.12)',
+        raisedHover: '0 2px 6px rgba(0, 0, 0, 0.15)',
+        pressed: '0 1px 2px rgba(0, 0, 0, 0.1)',
+        nav: '0 -2px 10px rgba(0, 0, 0, 0.08)',
+        menu: '0 4px 16px rgba(0, 0, 0, 0.2)',
+    },
+    focus: {
+        ring: '2px solid rgba(0, 122, 255, 0.45)',
+        offset: '2px',
+    },
+    motion: {
+        fast: '0.15s ease-out',
+        standard: '0.2s ease-out',
+    },
+    zIndex: {
+        nav: 20,
+        overlay: 9999,
+    },
+} as const;
+
+export const uiTokenCssVariables = {
+    '--inventory-color-canvas': uiTokens.color.canvas,
+    '--inventory-color-brand': uiTokens.color.brand,
+    '--inventory-color-brand-subtle': uiTokens.color.brandSubtle,
+    '--inventory-color-text': uiTokens.color.text,
+    '--inventory-color-text-weak': uiTokens.color.textWeak,
+    '--inventory-color-text-muted': uiTokens.color.textMuted,
+    '--inventory-color-border': uiTokens.color.border,
+    '--inventory-color-border-subtle': uiTokens.color.borderSubtle,
+    '--inventory-color-surface': uiTokens.color.surface,
+    '--inventory-color-surface-raised': uiTokens.color.surfaceRaised,
+    '--inventory-font-family': uiTokens.font.family,
+    '--inventory-font-size-body': uiTokens.font.size,
+    '--inventory-radius-control': uiTokens.radius.control,
+    '--inventory-size-touch-target': uiTokens.size.touchTarget,
+    '--inventory-size-mobile-nav': uiTokens.size.mobileNav,
+    '--inventory-shadow-nav': uiTokens.shadow.nav,
+    '--inventory-focus-ring': uiTokens.focus.ring,
+    '--inventory-focus-offset': uiTokens.focus.offset,
+    '--inventory-z-nav': uiTokens.zIndex.nav,
+} as const;
+
+const cssVariableDeclarations = Object.entries(uiTokenCssVariables)
+    .map(([name, value]) => `        ${name}: ${String(value)};`)
+    .join('\n');
+
+export const DesignSystemGlobalStyle = createGlobalStyle`
+    :root {
+${cssVariableDeclarations}
+    }
+
+    html {
+        color-scheme: light;
+        background: var(--inventory-color-canvas);
+    }
+
+    body {
+        color: var(--inventory-color-text);
+        background: var(--inventory-color-canvas);
+        font-family: var(--inventory-font-family);
+        font-size: var(--inventory-font-size-body);
+    }
+
+    :focus-visible {
+        outline: var(--inventory-focus-ring);
+        outline-offset: var(--inventory-focus-offset);
+    }
+`;
+
+// Grommet theme with iOS-style design and touch-friendly sizing.
+export const theme = {
+    global: {
+        colors: {
+            brand: uiTokens.color.brand,
+            focus: uiTokens.color.brand,
+            'status-critical': uiTokens.color.danger,
+            'status-ok': uiTokens.color.success,
+            'status-warning': uiTokens.color.warning,
+        },
+        font: {
+            family: uiTokens.font.family,
+            size: uiTokens.font.size,
+        },
+        control: {
+            border: {
+                radius: uiTokens.radius.control,
+            },
+        },
+        edgeSize: {
+            xsmall: uiTokens.space.xs,
+            small: uiTokens.space.sm,
+            medium: uiTokens.space.lg,
+            large: uiTokens.space.xxl,
+        },
+    },
+    button: {
+        default: {
+            padding: {
+                vertical: uiTokens.space.md,
+                horizontal: uiTokens.space.xl,
+            },
+        },
+        border: {
+            radius: uiTokens.radius.control,
+        },
+    },
+    formField: {
+        border: false,
+        content: {
+            pad: { vertical: 'small' },
+        },
+    },
+    textInput: {
+        extend: `
+            min-height: ${uiTokens.size.touchTarget};
+            padding: ${uiTokens.space.md} ${uiTokens.space.lg};
+        `,
+    },
+    textArea: {
+        extend: `
+            min-height: ${uiTokens.size.touchTarget};
+            padding: ${uiTokens.space.md} ${uiTokens.space.lg};
+        `,
+    },
+    select: {
+        container: {
+            extend: `
+                min-height: ${uiTokens.size.touchTarget};
+            `,
+        },
+    },
+};


### PR DESCRIPTION
## Summary

- Add a lightweight design-system guide with product feel, token meanings, component standards, and a feature design requirements template.
- Move the app-level Grommet theme into a shared `theme.ts` token module with CSS custom properties and global focus/body styles.
- Start migrating shared UI surfaces onto tokens, including touch buttons, filter chips, tag chips, loading states, tag/item list affordances, and navigation button sizing.

## Validation

- `npm run check:type`
- Prettier checks for changed docs and UI files