### PR TITLE
[codex] address audit issue batch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ playwright-report/
 test-results/
 tests/e2e/audit/artifacts/
 .playwright/
+.playwright-cli/
 tests/e2e/app/temp-download.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -12,6 +12,7 @@ specs/
 node_modules/
 test-results/
 playwright-report/
+.playwright-cli/
 
 # Generated files
 package-lock.json

--- a/meteor-app/client/main.css
+++ b/meteor-app/client/main.css
@@ -31,6 +31,8 @@ body {
 }
 
 .app-shell-title {
+    font-size: 24px;
+    font-weight: 700;
     line-height: 1.2;
     white-space: nowrap;
 }
@@ -40,17 +42,61 @@ body {
 }
 
 .app-shell-nav-link {
-    color: inherit;
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    min-height: 44px;
+    padding: 8px 16px;
+    color: #ffffff;
     text-decoration: none;
+    border-radius: 8px;
+    transition: background-color 0.15s ease-out, color 0.15s ease-out;
 }
 
-.app-shell-desktop-nav-button {
-    min-height: 44px;
+.app-shell-nav-link:hover,
+.app-shell-nav-link:focus-visible {
+    background: rgb(255 255 255 / 20%);
+}
+
+.app-shell-nav-link-active {
+    background: rgb(255 255 255 / 28%);
+}
+
+.app-shell-nav-link-icon {
+    flex: 0 0 auto;
+    width: 20px;
+    height: 20px;
+}
+
+.app-shell-nav-link-icon svg {
+    width: 20px;
+    height: 20px;
 }
 
 .app-shell-main {
     min-width: 0;
     width: 100%;
+}
+
+.app-primary-link-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 44px;
+    padding: 12px 20px;
+    color: #ffffff;
+    font-weight: 600;
+    line-height: 1;
+    text-align: center;
+    text-decoration: none;
+    background: #007aff;
+    border-radius: 8px;
+    transition: background-color 0.15s ease-out, box-shadow 0.15s ease-out;
+}
+
+.app-primary-link-button:hover,
+.app-primary-link-button:focus-visible {
+    background: #0051d5;
 }
 
 .app-shell-mobile-nav {

--- a/meteor-app/imports/ui/AllItemsView/AllItemsViewContainer.tsx
+++ b/meteor-app/imports/ui/AllItemsView/AllItemsViewContainer.tsx
@@ -1,16 +1,39 @@
+/**
+ * Meteor-backed container for the hierarchical inventory list.
+ * Keeps publication state, current-container selection, breadcrumbs, and route updates
+ * out of the presentational list component.
+ */
 import type { Mongo } from 'meteor/mongo';
-import React, { type ComponentProps, type ReactElement, useState, useCallback } from 'react';
+import React, { type ComponentProps, type ReactElement, useState, useCallback, useEffect } from 'react';
 import { useLocation } from 'wouter';
 
 import { InventoryItemsCollection, type InventoryItem } from '/imports/api/items';
 import type { SearchFragment } from '/imports/model/SearchFragment';
 import { AllItemsViewPresentation } from '/imports/ui/AllItemsView/AllItemsViewPresentation';
 import { LoadingState } from '/imports/ui/common/LoadingState';
+import { compareNaturalText } from '/imports/utility/naturalSort';
 import { useSubscribe, useTracker } from '/imports/utility/reactMeteorData';
 import { buildSearchQuery } from '/imports/utility/searchQuery';
 import { usePageTitle } from '/imports/utility/usePageTitle';
 
 const REFRESH_VISUAL_DELAY_MS = 500;
+
+const findInventoryItemById = (itemId: string): InventoryItem | undefined => {
+    return InventoryItemsCollection.find({ _id: itemId }, { limit: 1 }).fetch()[0];
+};
+
+const compareItemsForDisplay = (first: InventoryItem, second: InventoryItem): number => {
+    if (first.isContainer !== second.isContainer) {
+        return first.isContainer ? -1 : 1;
+    }
+
+    const byNaturalName = compareNaturalText(first.name, second.name);
+    if (byNaturalName !== 0) {
+        return byNaturalName;
+    }
+
+    return first.createdAt.getTime() - second.createdAt.getTime();
+};
 
 /**
  * AllItemsViewContainer is a container component that fetches data from Meteor and passes it
@@ -71,6 +94,10 @@ export const AllItemsViewContainer = ({
         });
     }, []);
 
+    useEffect(() => {
+        setCurrentContainerId(initialContainerId);
+    }, [initialContainerId]);
+
     const isLoadingItems = useSubscribe('items.byContainer', currentContainerId ?? null);
     const isLoadingTags = useSubscribe('tags.all');
 
@@ -90,23 +117,11 @@ export const AllItemsViewContainer = ({
                 $and: [baseQuery, filterQuery],
             };
 
-            return InventoryItemsCollection.find(combinedQuery, {
-                sort: [
-                    ['isContainer', 'desc'], // Containers first
-                    ['name', 'asc'],
-                    ['createdAt', 'asc'],
-                ],
-            }).fetch();
-        } else {
-            // No filters - just show items at current level
-            return InventoryItemsCollection.find(baseQuery, {
-                sort: [
-                    ['isContainer', 'desc'], // Containers first
-                    ['name', 'asc'],
-                    ['createdAt', 'asc'],
-                ],
-            }).fetch();
+            return InventoryItemsCollection.find(combinedQuery).fetch().sort(compareItemsForDisplay);
         }
+
+        // No filters - just show items at current level
+        return InventoryItemsCollection.find(baseQuery).fetch().sort(compareItemsForDisplay);
     }, [currentContainerId, JSON.stringify(filters), refreshTrigger]);
 
     // Fetch current container path for breadcrumb
@@ -114,17 +129,22 @@ export const AllItemsViewContainer = ({
         if (currentContainerId === undefined) {
             return [];
         }
-        const container = InventoryItemsCollection.findOne({ _id: currentContainerId });
+        const container = findInventoryItemById(currentContainerId);
         if (container === undefined) {
             return [];
         }
 
         const path: InventoryItem[] = [container];
+        const visitedContainerIds = new Set<string>([container._id]);
         let current = container;
         while (current.containerId !== undefined) {
-            const parent = InventoryItemsCollection.findOne({ _id: current.containerId });
+            if (visitedContainerIds.has(current.containerId)) break;
+
+            const parent = findInventoryItemById(current.containerId);
             if (parent === undefined) break;
+
             path.unshift(parent);
+            visitedContainerIds.add(parent._id);
             current = parent;
         }
         return path;
@@ -133,6 +153,7 @@ export const AllItemsViewContainer = ({
     const handleNavigateToContainer = (containerId: string | undefined): void => {
         setCurrentContainerId(containerId);
         onNavigate?.(containerId);
+        setLocation(containerId === undefined ? '/items' : `/container/${containerId}`);
     };
 
     if (isLoadingItems() || isLoadingTags()) {

--- a/meteor-app/imports/ui/AllItemsView/AllItemsViewPresentation.tsx
+++ b/meteor-app/imports/ui/AllItemsView/AllItemsViewPresentation.tsx
@@ -1,7 +1,13 @@
+/**
+ * Presentational inventory list for the current container level.
+ * Owns list-row semantics, touch gestures, breadcrumbs, and context-menu affordances,
+ * while container modules provide data and routing callbacks.
+ */
 import { Box, List, Text } from 'grommet';
 import { Folder, Next } from 'grommet-icons';
 import React, { type ComponentProps, type ReactElement, useRef } from 'react';
 import styled, { css, keyframes } from 'styled-components';
+import { Link } from 'wouter';
 
 import type { InventoryItem } from '/imports/model/InventoryItem';
 import { BreadcrumbTrail } from '/imports/ui/BreadcrumbTrail';
@@ -48,6 +54,17 @@ const PullToRefreshIndicator = styled.div`
     pointer-events: none;
     z-index: 100;
     transition: transform 0.2s ease-out, opacity 0.2s ease-out;
+`;
+
+const ItemRowLink = styled(Link)`
+    display: block;
+    color: inherit;
+    text-decoration: none;
+
+    &:focus-visible {
+        outline: 3px solid #007aff;
+        outline-offset: 2px;
+    }
 `;
 
 /**
@@ -274,41 +291,43 @@ export const AllItemsViewPresentation = ({
                             }
                             return (
                                 <LongPressContextMenu key={item._id} actions={menuActions}>
-                                    <Box
-                                        direction="row"
-                                        align="center"
-                                        pad="small"
-                                        gap="small"
-                                        background="background-front"
-                                        hoverIndicator="background-contrast"
-                                        style={{
-                                            minHeight: '44px',
-                                            cursor: 'pointer',
-                                        }}
-                                        onClick={() => {
-                                            if (item.isContainer) {
-                                                onNavigateToContainer(item._id);
-                                            } else if (onViewItemDetails !== undefined) {
-                                                onViewItemDetails(item._id);
-                                            }
-                                        }}
+                                    <ItemRowLink
+                                        href={item.isContainer ? `/container/${item._id}` : `/items/${item._id}`}
+                                        aria-label={
+                                            item.isContainer ? `Open container ${item.name}` : `View item ${item.name}`
+                                        }
                                     >
-                                        {/* Icon for containers */}
-                                        {item.isContainer && <Folder size="medium" color="brand" />}
+                                        <Box
+                                            direction="row"
+                                            align="center"
+                                            pad="small"
+                                            gap="small"
+                                            background="background-front"
+                                            hoverIndicator="background-contrast"
+                                            style={{
+                                                minHeight: '44px',
+                                                cursor: 'pointer',
+                                            }}
+                                        >
+                                            {/* Icon for containers */}
+                                            {item.isContainer && <Folder size="medium" color="brand" />}
 
-                                        {/* Item name */}
-                                        <Box flex>
-                                            <Text weight={item.isContainer ? 'bold' : 'normal'}>{item.name}</Text>
-                                            {item.description !== '' && item.description !== undefined && (
-                                                <Text size="small" color="text-weak" truncate>
-                                                    {item.description}
+                                            {/* Item name */}
+                                            <Box flex style={{ minWidth: 0 }}>
+                                                <Text weight={item.isContainer ? 'bold' : 'normal'} truncate>
+                                                    {item.name}
                                                 </Text>
-                                            )}
-                                        </Box>
+                                                {item.description !== '' && item.description !== undefined && (
+                                                    <Text size="small" color="text-weak" truncate>
+                                                        {item.description}
+                                                    </Text>
+                                                )}
+                                            </Box>
 
-                                        {/* Navigation arrow for containers */}
-                                        {item.isContainer && <Next size="medium" color="text-weak" />}
-                                    </Box>
+                                            {/* Navigation arrow for containers */}
+                                            {item.isContainer && <Next size="medium" color="text-weak" />}
+                                        </Box>
+                                    </ItemRowLink>
                                 </LongPressContextMenu>
                             );
                         }}

--- a/meteor-app/imports/ui/App.tsx
+++ b/meteor-app/imports/ui/App.tsx
@@ -429,7 +429,9 @@ export const App = (): ReactElement => {
                     </Route>
 
                     {/* Item detail route */}
-                    <Route path="/items/:itemId">{() => <ItemDetailView />}</Route>
+                    <Route path="/items/:itemId">
+                        {() => <ItemDetailView deleteReturnPath={isSearchResultItemDetail ? '/search' : undefined} />}
+                    </Route>
 
                     {/* Items by tag route */}
                     <Route path="/tags/:tagId">{() => <ItemsByTagView />}</Route>

--- a/meteor-app/imports/ui/App.tsx
+++ b/meteor-app/imports/ui/App.tsx
@@ -1,3 +1,7 @@
+/**
+ * Top-level application shell and route composition.
+ * Coordinates URL-backed inventory views, creation modal state, and cross-view search state.
+ */
 import { Box, Button, Grommet, Heading, Layer, Text } from 'grommet';
 import { Add, Close, Filter } from 'grommet-icons';
 import { Meteor } from 'meteor/meteor';
@@ -5,20 +9,18 @@ import React, { type ReactElement, useState, useEffect } from 'react';
 import { Route, Switch, useLocation } from 'wouter';
 
 import Items, { InventoryItemsCollection } from '/imports/api/items';
-import Tags, { TagsCollection } from '/imports/api/tags';
+import { TagsCollection } from '/imports/api/tags';
 import type { InventoryItem } from '/imports/model/InventoryItem';
 import type { SearchFragment } from '/imports/model/SearchFragment';
 import { LoadingState } from '/imports/ui/common/LoadingState';
-import { getValidMoveTargetContainers } from '/imports/utility/moveTargets';
 import { useSubscribe, useTracker } from '/imports/utility/reactMeteorData';
 import type RecordInput from '/imports/utility/RecordInput';
 
 import { AllItemsView } from './AllItemsView';
 import { AllTagsView } from './AllTagsView';
 import { AppShell } from './AppShell';
-import { ContainerSelector } from './ContainerSelector';
 import { FilterBar } from './FilterBar';
-import { ItemDetailView, ItemDetailViewPresentation } from './ItemDetailView';
+import { ItemDetailView } from './ItemDetailView';
 import { ItemForm } from './ItemForm';
 import { ItemsByTagView } from './ItemsByTagView';
 import { NotFoundView } from './NotFoundView';
@@ -29,27 +31,46 @@ import { SearchScopeSelector } from './SearchScopeSelector';
 import { SettingsDataView } from './SettingsDataView';
 import { DesignSystemGlobalStyle, theme } from './theme';
 
-const getErrorMessage = (error: unknown): string => {
-    return error instanceof Error ? error.message : 'Something went wrong. Please try again.';
+const SEARCH_RESULT_ITEM_DETAIL_SOURCE = 'search-results';
+
+interface ItemDetailNavigationState {
+    inventoryItemDetailSource?: typeof SEARCH_RESULT_ITEM_DETAIL_SOURCE;
+}
+
+const findInventoryItemById = (itemId: string): InventoryItem | undefined => {
+    return InventoryItemsCollection.find({ _id: itemId }, { limit: 1 }).fetch()[0];
 };
 
-const getNonEmptyContainerMessage = (childCount: number): string => {
-    return `Cannot delete container with ${childCount} child ${
-        childCount === 1 ? 'item' : 'items'
-    }. Move or delete children first.`;
+const isSearchResultItemDetailState = (state: unknown): state is ItemDetailNavigationState => {
+    return (
+        typeof state === 'object' &&
+        state !== null &&
+        (state as ItemDetailNavigationState).inventoryItemDetailSource === SEARCH_RESULT_ITEM_DETAIL_SOURCE
+    );
+};
+
+const getCurrentHistoryState = (): unknown => {
+    if (typeof window === 'undefined') return undefined;
+    return window.history.state;
+};
+
+const decodeRouteParam = (routeParam: string): string | undefined => {
+    try {
+        const decodedParam = decodeURIComponent(routeParam);
+        return decodedParam.length > 0 ? decodedParam : undefined;
+    } catch {
+        return undefined;
+    }
 };
 
 export const App = (): ReactElement => {
-    const [location] = useLocation();
+    const [location, setLocation] = useLocation();
+    const isSearchResultItemDetail = isSearchResultItemDetailState(getCurrentHistoryState());
     const [showCreateItem, setShowCreateItem] = useState(false);
-    const [selectedItemId, setSelectedItemId] = useState<string | undefined>();
     const [currentItemsContainerId, setCurrentItemsContainerId] = useState<string | undefined>();
-    const [isEditingSelectedItem, setIsEditingSelectedItem] = useState(false);
-    const [isMovingSelectedItem, setIsMovingSelectedItem] = useState(false);
-    const [isConfirmingSelectedDelete, setIsConfirmingSelectedDelete] = useState(false);
-    const [selectedMoveTargetId, setSelectedMoveTargetId] = useState<string | undefined>();
-    const [isSubmittingSelectedItem, setIsSubmittingSelectedItem] = useState(false);
-    const [selectedItemError, setSelectedItemError] = useState<string | undefined>();
+    const containerRouteMatch = /^\/container\/([^/]+)$/.exec(location);
+    const isContainerRoute = containerRouteMatch !== null;
+    const routeContainerId = containerRouteMatch !== null ? decodeRouteParam(containerRouteMatch[1]) : undefined;
 
     // Search state
     const [searchQuery, setSearchQuery] = useState('');
@@ -64,66 +85,60 @@ export const App = (): ReactElement => {
     const [itemsViewFilters, setItemsViewFilters] = useState<SearchFragment[]>([]);
     const [showFilterBuilder, setShowFilterBuilder] = useState(false);
 
-    // Fetch selected item for detail view
-    const isLoadingSelectedItem = useSubscribe('items.byId', selectedItemId ?? '');
-    const selectedItem = useTracker(() => {
-        if (selectedItemId === undefined) return undefined;
-        return InventoryItemsCollection.findOne({ _id: selectedItemId });
-    }, [selectedItemId]);
-
-    // Fetch tags for selected item
-    const selectedItemTags = useTracker(() => {
-        if (selectedItem === undefined) return [];
-        return TagsCollection.find({ _id: { $in: selectedItem.tagIds } }).fetch();
-    }, [selectedItem?.tagIds.join(',')]);
-
-    const selectedItemChildCount = useTracker(() => {
-        if (selectedItemId === undefined) return 0;
-        return InventoryItemsCollection.find({ containerId: selectedItemId }).count();
-    }, [selectedItemId]);
-
     // Fetch all tags for search components
     const isLoadingTags = useSubscribe('tags.all');
     const isLoadingAllItems = useSubscribe('items.all');
+    const tagsLoading = isLoadingTags();
+    const allItemsLoading = isLoadingAllItems();
     const allTags = useTracker(() => {
         return TagsCollection.find({}, { sort: { name: 1 } }).fetch();
     }, []);
 
-    const availableContainers = useTracker(() => {
-        const containers = InventoryItemsCollection.find(
-            { isContainer: true, _id: { $ne: selectedItemId } },
-            { sort: { name: 1 } }
-        ).fetch();
-        return getValidMoveTargetContainers(containers, selectedItemId);
-    }, [selectedItemId]);
+    const routeContainer = useTracker(() => {
+        if (routeContainerId === undefined) return undefined;
+        return findInventoryItemById(routeContainerId);
+    }, [routeContainerId]);
 
     const currentSearchScopeItem = useTracker(() => {
         if (currentItemsContainerId === undefined) return undefined;
-        return InventoryItemsCollection.findOne({ _id: currentItemsContainerId });
+        return findInventoryItemById(currentItemsContainerId);
     }, [currentItemsContainerId]);
 
     // Clear filters when navigating between views
     useEffect(() => {
+        const itemDetailRouteMatch = /^\/items\/[^/]+$/.exec(location);
+        setShowCreateItem(false);
         setItemsViewFilters([]);
         setShowFilterBuilder(false);
-        if (location !== '/' && location !== '/items' && location !== '/search') {
+
+        if (isContainerRoute) {
+            setCurrentItemsContainerId(routeContainerId);
+        } else if (location === '/' || location === '/items') {
+            setCurrentItemsContainerId(undefined);
+        } else if (itemDetailRouteMatch !== null) {
+            if (!isSearchResultItemDetail) {
+                setCurrentItemsContainerId(undefined);
+            }
+        } else if (location !== '/search') {
             setCurrentItemsContainerId(undefined);
         }
-    }, [location]);
+    }, [isContainerRoute, isSearchResultItemDetail, location, routeContainerId]);
+
+    useEffect(() => {
+        if (!isContainerRoute || routeContainerId === undefined || allItemsLoading) return;
+
+        if (routeContainer?.isContainer === true) {
+            setCurrentItemsContainerId(routeContainerId);
+        } else {
+            setCurrentItemsContainerId(undefined);
+        }
+    }, [allItemsLoading, isContainerRoute, routeContainer?._id, routeContainer?.isContainer, routeContainerId]);
 
     useEffect(() => {
         if (currentItemsContainerId === undefined && searchScope === 'scoped') {
             setSearchScope('global');
         }
     }, [currentItemsContainerId, searchScope]);
-
-    const handleCloseItemDetail = (): void => {
-        setSelectedItemId(undefined);
-        setIsEditingSelectedItem(false);
-        setIsMovingSelectedItem(false);
-        setIsConfirmingSelectedDelete(false);
-        setSelectedItemError(undefined);
-    };
 
     const handleCreateItem = async (itemData: RecordInput<InventoryItem>): Promise<void> => {
         try {
@@ -136,73 +151,6 @@ export const App = (): ReactElement => {
             setShowCreateItem(false);
         } catch (error) {
             console.error('Failed to create item:', error);
-        }
-    };
-
-    const handleDeleteItem = async (): Promise<void> => {
-        if (selectedItem === undefined) return;
-        if (selectedItem.isContainer && selectedItemChildCount > 0) {
-            setSelectedItemError(getNonEmptyContainerMessage(selectedItemChildCount));
-            return;
-        }
-
-        try {
-            setIsSubmittingSelectedItem(true);
-            setSelectedItemError(undefined);
-            await Items.deleteItem(selectedItem._id);
-            handleCloseItemDetail();
-        } catch (error) {
-            setSelectedItemError(getErrorMessage(error));
-            console.error('Failed to delete item:', error);
-        } finally {
-            setIsSubmittingSelectedItem(false);
-        }
-    };
-
-    const handleUpdateSelectedItem = async (itemData: RecordInput<InventoryItem>): Promise<void> => {
-        if (selectedItem === undefined) return;
-        try {
-            setIsSubmittingSelectedItem(true);
-            setSelectedItemError(undefined);
-            await Items.updateItem(selectedItem._id, {
-                name: itemData.name,
-                description: itemData.description,
-                isContainer: itemData.isContainer,
-                tagIds: itemData.tagIds,
-                properties: itemData.properties,
-            });
-            setIsEditingSelectedItem(false);
-        } catch (error) {
-            setSelectedItemError(getErrorMessage(error));
-            console.error('Failed to update item:', error);
-        } finally {
-            setIsSubmittingSelectedItem(false);
-        }
-    };
-
-    const handleMoveSelectedItem = async (): Promise<void> => {
-        if (selectedItem === undefined) return;
-        try {
-            setIsSubmittingSelectedItem(true);
-            setSelectedItemError(undefined);
-            await Items.moveItem(selectedItem._id, selectedMoveTargetId);
-            setIsMovingSelectedItem(false);
-        } catch (error) {
-            setSelectedItemError(getErrorMessage(error));
-            console.error('Failed to move item:', error);
-        } finally {
-            setIsSubmittingSelectedItem(false);
-        }
-    };
-
-    const handleRemoveTagFromItem = async (tagId: string): Promise<void> => {
-        if (selectedItem === undefined) return;
-        try {
-            setSelectedItemError(undefined);
-            await Tags.removeFromItem(selectedItem._id, tagId);
-        } catch (error) {
-            setSelectedItemError(getErrorMessage(error));
-            console.error('Failed to remove tag from item:', error);
         }
     };
 
@@ -242,15 +190,15 @@ export const App = (): ReactElement => {
     };
 
     const handleSearchItemClick = (itemId: string): void => {
-        setSelectedItemError(undefined);
-        setIsEditingSelectedItem(false);
-        setIsMovingSelectedItem(false);
-        setIsConfirmingSelectedDelete(false);
-        setSelectedItemId(itemId);
+        setLocation(`/items/${itemId}`, {
+            state: {
+                inventoryItemDetailSource: SEARCH_RESULT_ITEM_DETAIL_SOURCE,
+            },
+        });
     };
 
     const getItemPath = (pathItemId: string): InventoryItem[] => {
-        const item = InventoryItemsCollection.findOne({ _id: pathItemId });
+        const item = findInventoryItemById(pathItemId);
         if (item === undefined) return [];
 
         const path: InventoryItem[] = [item];
@@ -260,7 +208,7 @@ export const App = (): ReactElement => {
         while (currentItem.containerId !== undefined) {
             if (visitedItemIds.has(currentItem.containerId)) break;
 
-            const parent = InventoryItemsCollection.findOne({ _id: currentItem.containerId });
+            const parent = findInventoryItemById(currentItem.containerId);
             if (parent === undefined) break;
 
             path.unshift(parent);
@@ -278,127 +226,119 @@ export const App = (): ReactElement => {
         setShowFilterBuilder(false);
     };
 
+    const getItemsViewHeading = (initialContainerId?: string): string => {
+        if (initialContainerId === undefined) return 'All Items';
+        return findInventoryItemById(initialContainerId)?.name ?? 'Container';
+    };
+
+    const renderItemsView = (initialContainerId?: string): ReactElement => {
+        return (
+            <Box>
+                <Box direction="row" justify="between" align="center" margin={{ bottom: 'medium' }}>
+                    <Heading level="2" margin="none">
+                        {getItemsViewHeading(initialContainerId)}
+                    </Heading>
+                    <Box direction="row" gap="small">
+                        <Button
+                            icon={<Filter />}
+                            label={showFilterBuilder ? 'Hide Filters' : 'Add Filters'}
+                            onClick={() => {
+                                setShowFilterBuilder(!showFilterBuilder);
+                            }}
+                            secondary={!showFilterBuilder}
+                            primary={showFilterBuilder}
+                        />
+                        <Button
+                            icon={<Add />}
+                            label="Create Item"
+                            primary
+                            onClick={() => {
+                                setShowCreateItem(true);
+                            }}
+                        />
+                    </Box>
+                </Box>
+
+                {/* Filter status and clear */}
+                {itemsViewFilters.length > 0 && (
+                    <Box margin={{ bottom: 'medium' }}>
+                        <FilterBar
+                            filters={itemsViewFilters}
+                            onChange={setItemsViewFilters}
+                            onClearAll={() => {
+                                setItemsViewFilters([]);
+                            }}
+                            availableTags={allTags}
+                        />
+                    </Box>
+                )}
+
+                {/* Filter builder (collapsible) */}
+                {showFilterBuilder && (
+                    <Box margin={{ bottom: 'medium' }} pad="medium" background="light-2" round="small">
+                        <SearchFragmentBuilder
+                            fragments={itemsViewFilters}
+                            onChange={setItemsViewFilters}
+                            availableTags={allTags}
+                        />
+                    </Box>
+                )}
+
+                <AllItemsView
+                    initialContainerId={initialContainerId}
+                    filters={itemsViewFilters}
+                    onNavigate={handleItemsViewNavigate}
+                />
+            </Box>
+        );
+    };
+
+    const renderInvalidContainerView = (): ReactElement => {
+        return (
+            <Box fill align="center" justify="center" gap="medium" pad="large">
+                <Heading level={3} color="status-error">
+                    Container Not Found
+                </Heading>
+                <Text>The container you're looking for doesn't exist, is not a container, or has been deleted.</Text>
+                <a href="/items" className="app-primary-link-button">
+                    Go to Items
+                </a>
+            </Box>
+        );
+    };
+
+    const renderContainerRoute = (rawRouteContainerId: string): ReactElement => {
+        const containerId = decodeRouteParam(rawRouteContainerId);
+        if (containerId === undefined) {
+            return renderInvalidContainerView();
+        }
+
+        if (allItemsLoading) {
+            return <LoadingState />;
+        }
+
+        const container = containerId === routeContainerId ? routeContainer : findInventoryItemById(containerId);
+        if (container?.isContainer !== true) {
+            return renderInvalidContainerView();
+        }
+
+        return renderItemsView(containerId);
+    };
+
     return (
         <Grommet theme={theme} full>
             <DesignSystemGlobalStyle />
             <AppShell location={location}>
                 <Switch>
                     {/* Home route - Items view */}
-                    <Route path="/">
-                        {() => (
-                            <Box>
-                                <Box direction="row" justify="between" align="center" margin={{ bottom: 'medium' }}>
-                                    <Heading level="2" margin="none">
-                                        Items
-                                    </Heading>
-                                    <Box direction="row" gap="small">
-                                        <Button
-                                            icon={<Filter />}
-                                            label={showFilterBuilder ? 'Hide Filters' : 'Add Filters'}
-                                            onClick={() => {
-                                                setShowFilterBuilder(!showFilterBuilder);
-                                            }}
-                                            secondary={!showFilterBuilder}
-                                            primary={showFilterBuilder}
-                                        />
-                                        <Button
-                                            icon={<Add />}
-                                            label="Create Item"
-                                            primary
-                                            onClick={() => {
-                                                setShowCreateItem(true);
-                                            }}
-                                        />
-                                    </Box>
-                                </Box>
-
-                                {/* Filter status and clear */}
-                                {itemsViewFilters.length > 0 && (
-                                    <Box margin={{ bottom: 'medium' }}>
-                                        <FilterBar
-                                            filters={itemsViewFilters}
-                                            onChange={setItemsViewFilters}
-                                            onClearAll={() => {
-                                                setItemsViewFilters([]);
-                                            }}
-                                            availableTags={allTags}
-                                        />
-                                    </Box>
-                                )}
-
-                                {/* Filter builder (collapsible) */}
-                                {showFilterBuilder && (
-                                    <Box margin={{ bottom: 'medium' }} pad="medium" background="light-2" round="small">
-                                        <SearchFragmentBuilder
-                                            fragments={itemsViewFilters}
-                                            onChange={setItemsViewFilters}
-                                            availableTags={allTags}
-                                        />
-                                    </Box>
-                                )}
-
-                                <AllItemsView filters={itemsViewFilters} onNavigate={handleItemsViewNavigate} />
-                            </Box>
-                        )}
-                    </Route>
+                    <Route path="/">{() => renderItemsView()}</Route>
 
                     {/* Items list route */}
-                    <Route path="/items">
-                        {() => (
-                            <Box>
-                                <Box direction="row" justify="between" align="center" margin={{ bottom: 'medium' }}>
-                                    <Heading level="2" margin="none">
-                                        Items
-                                    </Heading>
-                                    <Box direction="row" gap="small">
-                                        <Button
-                                            icon={<Filter />}
-                                            label={showFilterBuilder ? 'Hide Filters' : 'Add Filters'}
-                                            onClick={() => {
-                                                setShowFilterBuilder(!showFilterBuilder);
-                                            }}
-                                            secondary={!showFilterBuilder}
-                                            primary={showFilterBuilder}
-                                        />
-                                        <Button
-                                            icon={<Add />}
-                                            label="Create Item"
-                                            primary
-                                            onClick={() => {
-                                                setShowCreateItem(true);
-                                            }}
-                                        />
-                                    </Box>
-                                </Box>
+                    <Route path="/items">{() => renderItemsView()}</Route>
 
-                                {/* Filter status and clear */}
-                                {itemsViewFilters.length > 0 && (
-                                    <Box margin={{ bottom: 'medium' }}>
-                                        <FilterBar
-                                            filters={itemsViewFilters}
-                                            onChange={setItemsViewFilters}
-                                            onClearAll={() => {
-                                                setItemsViewFilters([]);
-                                            }}
-                                            availableTags={allTags}
-                                        />
-                                    </Box>
-                                )}
-
-                                {/* Filter builder (collapsible) */}
-                                {showFilterBuilder && (
-                                    <Box margin={{ bottom: 'medium' }} pad="medium" background="light-2" round="small">
-                                        <SearchFragmentBuilder
-                                            fragments={itemsViewFilters}
-                                            onChange={setItemsViewFilters}
-                                            availableTags={allTags}
-                                        />
-                                    </Box>
-                                )}
-
-                                <AllItemsView filters={itemsViewFilters} onNavigate={handleItemsViewNavigate} />
-                            </Box>
-                        )}
+                    {/* Container route */}
+                    <Route path="/container/:containerId">
+                        {({ containerId }) => renderContainerRoute(containerId)}
                     </Route>
 
                     {/* Tags list route */}
@@ -423,7 +363,7 @@ export const App = (): ReactElement => {
                                     />
                                 </Box>
 
-                                {isLoadingTags() || isLoadingAllItems() ? (
+                                {tagsLoading || allItemsLoading ? (
                                     <LoadingState />
                                 ) : (
                                     <>
@@ -530,135 +470,6 @@ export const App = (): ReactElement => {
                                     setShowCreateItem(false);
                                 }}
                             />
-                        </Box>
-                    </Layer>
-                )}
-
-                {/* Item Detail Modal */}
-                {selectedItemId !== undefined && (
-                    <Layer onEsc={handleCloseItemDetail} onClickOutside={handleCloseItemDetail}>
-                        <Box
-                            pad="medium"
-                            gap="medium"
-                            width="large"
-                            overflow="auto"
-                            style={{ WebkitOverflowScrolling: 'touch' }}
-                        >
-                            <Box direction="row" justify="between" align="center">
-                                <Heading level="3" margin="none">
-                                    Item Details
-                                </Heading>
-                                <Button icon={<Close />} onClick={handleCloseItemDetail} />
-                            </Box>
-                            {isLoadingSelectedItem() || isLoadingAllItems() || isLoadingTags() ? (
-                                <LoadingState />
-                            ) : selectedItem !== undefined && isConfirmingSelectedDelete ? (
-                                <Box gap="medium">
-                                    <Text>Delete "{selectedItem.name}"? This cannot be undone.</Text>
-                                    {selectedItem.isContainer && (
-                                        <Text color="text-weak" size="small">
-                                            Containers must be empty before they can be deleted.
-                                        </Text>
-                                    )}
-                                    {selectedItemError !== undefined && (
-                                        <Text color="status-critical">{selectedItemError}</Text>
-                                    )}
-                                    <Box direction="row" justify="end" gap="small">
-                                        <Button
-                                            label="Cancel"
-                                            onClick={() => {
-                                                setIsConfirmingSelectedDelete(false);
-                                            }}
-                                            disabled={isSubmittingSelectedItem}
-                                        />
-                                        <Button
-                                            primary
-                                            color="status-critical"
-                                            label="Delete Item"
-                                            onClick={() => {
-                                                void handleDeleteItem();
-                                            }}
-                                            disabled={isSubmittingSelectedItem}
-                                        />
-                                    </Box>
-                                </Box>
-                            ) : selectedItem !== undefined && isEditingSelectedItem ? (
-                                <Box gap="medium">
-                                    {selectedItemError !== undefined && (
-                                        <Text color="status-critical">{selectedItemError}</Text>
-                                    )}
-                                    <ItemForm
-                                        initialValues={selectedItem}
-                                        availableTags={allTags}
-                                        onSubmit={handleUpdateSelectedItem}
-                                        onCancel={() => {
-                                            setIsEditingSelectedItem(false);
-                                        }}
-                                        isSubmitting={isSubmittingSelectedItem}
-                                    />
-                                </Box>
-                            ) : selectedItem !== undefined && isMovingSelectedItem ? (
-                                <Box gap="medium">
-                                    {selectedItemError !== undefined && (
-                                        <Text color="status-critical">{selectedItemError}</Text>
-                                    )}
-                                    <ContainerSelector
-                                        containers={availableContainers}
-                                        selectedContainerId={selectedMoveTargetId}
-                                        onSelect={setSelectedMoveTargetId}
-                                        disabled={isSubmittingSelectedItem}
-                                    />
-                                    <Box direction="row" justify="end" gap="small">
-                                        <Button
-                                            label="Cancel"
-                                            onClick={() => {
-                                                setIsMovingSelectedItem(false);
-                                            }}
-                                            disabled={isSubmittingSelectedItem}
-                                        />
-                                        <Button
-                                            primary
-                                            label="Move Item"
-                                            onClick={() => {
-                                                void handleMoveSelectedItem();
-                                            }}
-                                            disabled={isSubmittingSelectedItem}
-                                        />
-                                    </Box>
-                                </Box>
-                            ) : selectedItem !== undefined ? (
-                                <ItemDetailViewPresentation
-                                    item={selectedItem}
-                                    tags={selectedItemTags}
-                                    onEdit={() => {
-                                        setSelectedItemError(undefined);
-                                        setIsConfirmingSelectedDelete(false);
-                                        setIsEditingSelectedItem(true);
-                                    }}
-                                    onMove={() => {
-                                        setSelectedItemError(undefined);
-                                        setIsConfirmingSelectedDelete(false);
-                                        setSelectedMoveTargetId(selectedItem.containerId);
-                                        setIsMovingSelectedItem(true);
-                                    }}
-                                    onDelete={() => {
-                                        setSelectedItemError(undefined);
-                                        setIsConfirmingSelectedDelete(true);
-                                        return undefined;
-                                    }}
-                                    onRemoveTag={(tagId) => {
-                                        void handleRemoveTagFromItem(tagId);
-                                        return undefined;
-                                    }}
-                                    disabled={isSubmittingSelectedItem}
-                                />
-                            ) : (
-                                <Box align="center" pad="large">
-                                    <Heading level="3" color="status-error">
-                                        Item Not Found
-                                    </Heading>
-                                </Box>
-                            )}
                         </Box>
                     </Layer>
                 )}

--- a/meteor-app/imports/ui/AppShell.tsx
+++ b/meteor-app/imports/ui/AppShell.tsx
@@ -1,4 +1,8 @@
-import { Box, Button, Header, Heading, Main, Nav, Text } from 'grommet';
+/**
+ * Responsive application chrome for primary navigation.
+ * Keeps the header landmark, desktop links, and mobile tab bar consistent across routes.
+ */
+import { Box, Header, Main, Nav, Text } from 'grommet';
 import { Apps, Configure, Search as SearchIcon, Tag as TagIcon } from 'grommet-icons';
 import React, { type ReactElement, type ReactNode } from 'react';
 import { Link } from 'wouter';
@@ -20,7 +24,7 @@ const navItems: NavItem[] = [
         href: '/items',
         label: 'Items',
         icon: <Apps />,
-        isActive: (location) => location === '/' || location.startsWith('/items'),
+        isActive: (location) => location === '/' || location.startsWith('/items') || location.startsWith('/container'),
     },
     {
         href: '/tags',
@@ -48,9 +52,9 @@ export const AppShell = ({ children, location }: AppShellProps): ReactElement =>
     return (
         <Box fill className="app-shell">
             <Header background="brand" pad={{ horizontal: 'medium', vertical: 'small' }} className="app-shell-header">
-                <Heading level="3" margin="none" color="white" className="app-shell-title">
+                <Text as="span" color="white" weight="bold" className="app-shell-title">
                     Inventory App
-                </Heading>
+                </Text>
                 <Nav
                     direction="row"
                     gap="xsmall"
@@ -65,15 +69,14 @@ export const AppShell = ({ children, location }: AppShellProps): ReactElement =>
                                 key={item.href}
                                 href={item.href}
                                 aria-current={getAriaCurrent(active)}
-                                className="app-shell-nav-link"
+                                className={`app-shell-nav-link${active ? ' app-shell-nav-link-active' : ''}`}
                             >
-                                <Button
-                                    icon={item.icon}
-                                    label={item.label}
-                                    primary={active}
-                                    plain={!active}
-                                    className="app-shell-desktop-nav-button"
-                                />
+                                <Box aria-hidden="true" className="app-shell-nav-link-icon">
+                                    {item.icon}
+                                </Box>
+                                <Text as="span" weight={active ? 'bold' : 'normal'}>
+                                    {item.label}
+                                </Text>
                             </Link>
                         );
                     })}

--- a/meteor-app/imports/ui/BreadcrumbTrail.tsx
+++ b/meteor-app/imports/ui/BreadcrumbTrail.tsx
@@ -1,19 +1,14 @@
+/**
+ * Shared breadcrumb trail for inventory hierarchy navigation.
+ * By default the final crumb represents the current location and is rendered
+ * as static text; callers with a container-only path can opt into making every
+ * crumb navigable.
+ */
 import { Home } from 'grommet-icons';
 import React from 'react';
 import styled from 'styled-components';
 
 import type { InventoryItem } from '/imports/model/InventoryItem';
-
-/**
- * Breadcrumb trail showing the path from root to current item.
- *
- * @remarks
- * Displays the container hierarchy as a clickable trail.
- * Each item in the path is a button that navigates to that container.
- * The current item (last in path) is not clickable.
- *
- * Touch targets are 44x44px minimum for iOS accessibility.
- */
 
 const BreadcrumbContainer = styled.nav`
     display: flex;
@@ -88,6 +83,9 @@ export interface BreadcrumbTrailProps {
     /** Show home icon for root instead of text */
     showHomeIcon?: boolean;
 
+    /** Whether the final crumb is the current location and should be static text */
+    lastCrumbIsCurrent?: boolean;
+
     /** Additional CSS class name */
     className?: string;
 }
@@ -102,6 +100,7 @@ export interface BreadcrumbTrailProps {
  *   path={path}
  *   onNavigate={(item) => navigateToContainer(item._id)}
  *   showHomeIcon
+ *   lastCrumbIsCurrent
  * />
  * ```
  */
@@ -110,6 +109,7 @@ export const BreadcrumbTrail: React.FC<BreadcrumbTrailProps> = ({
     onNavigate,
     onNavigateRoot,
     showHomeIcon = false,
+    lastCrumbIsCurrent = true,
     className,
 }) => {
     if (path.length === 0) {
@@ -118,7 +118,7 @@ export const BreadcrumbTrail: React.FC<BreadcrumbTrailProps> = ({
 
     const handleClick = (item: InventoryItem, index: number): void => {
         // Don't navigate to the current item (last in path)
-        if (index === path.length - 1) {
+        if (lastCrumbIsCurrent && index === path.length - 1) {
             return;
         }
 
@@ -150,7 +150,7 @@ export const BreadcrumbTrail: React.FC<BreadcrumbTrailProps> = ({
                     <React.Fragment key={item._id}>
                         {index > 0 && <Separator>›</Separator>}
 
-                        {isLast ? (
+                        {isLast && lastCrumbIsCurrent ? (
                             <BreadcrumbText>
                                 {showHome ? (
                                     <HomeIcon>

--- a/meteor-app/imports/ui/ContainerSelector.tsx
+++ b/meteor-app/imports/ui/ContainerSelector.tsx
@@ -1,8 +1,13 @@
+/**
+ * Selectable container list used when moving inventory items.
+ * Keeps move-target display concerns here while shared ordering logic lives in utility modules.
+ */
 import { Box, List, Text } from 'grommet';
 import { Folder, Home } from 'grommet-icons';
 import React from 'react';
 
 import type { InventoryItem } from '/imports/model/InventoryItem';
+import { compareNaturalText } from '/imports/utility/naturalSort';
 
 /**
  * Spacing constants for container hierarchy display
@@ -108,7 +113,7 @@ export const ContainerSelector: React.FC<ContainerSelectorProps> = ({
             return depthA - depthB;
         }
 
-        return a.name.localeCompare(b.name);
+        return compareNaturalText(a.name, b.name);
     });
 
     // Build list data including optional root

--- a/meteor-app/imports/ui/ItemDetailView.tsx
+++ b/meteor-app/imports/ui/ItemDetailView.tsx
@@ -1,3 +1,7 @@
+/**
+ * Route-backed item detail surface.
+ * Loads item data from the URL, renders editable detail states, and handles missing-item fallbacks.
+ */
 import { Box, Button, Heading, Layer, Text } from 'grommet';
 import { Close } from 'grommet-icons';
 import React, { useState } from 'react';
@@ -26,6 +30,10 @@ const getNonEmptyContainerMessage = (childCount: number): string => {
     return `Cannot delete container with ${childCount} child ${
         childCount === 1 ? 'item' : 'items'
     }. Move or delete children first.`;
+};
+
+const findInventoryItemById = (itemId: string): InventoryItem | undefined => {
+    return InventoryItemsCollection.find({ _id: itemId }, { limit: 1 }).fetch()[0];
 };
 
 /**
@@ -68,7 +76,7 @@ export const ItemDetailView: React.FC = () => {
     // Fetch item from database
     const item = useTracker(() => {
         if (itemId === '') return undefined;
-        return InventoryItemsCollection.findOne({ _id: itemId });
+        return findInventoryItemById(itemId);
     }, [itemId]);
 
     // Fetch tags for the item
@@ -94,6 +102,26 @@ export const ItemDetailView: React.FC = () => {
         return InventoryItemsCollection.find({ containerId: itemId }).count();
     }, [itemId]);
 
+    const containerPath = useTracker(() => {
+        if (item?.containerId === undefined) return [];
+
+        const path: InventoryItem[] = [];
+        const visitedContainerIds = new Set<string>();
+        let currentContainerId: string | undefined = item.containerId;
+
+        while (currentContainerId !== undefined && !visitedContainerIds.has(currentContainerId)) {
+            visitedContainerIds.add(currentContainerId);
+
+            const container = findInventoryItemById(currentContainerId);
+            if (container === undefined) break;
+
+            path.unshift(container);
+            currentContainerId = container.containerId;
+        }
+
+        return path;
+    }, [item?._id, item?.containerId]);
+
     if (isLoadingItem() || isLoadingAllItems() || isLoadingTags()) {
         return <LoadingState />;
     }
@@ -106,8 +134,8 @@ export const ItemDetailView: React.FC = () => {
                     Invalid Item ID
                 </Heading>
                 <Text>The item ID in the URL is missing or invalid.</Text>
-                <Link href="/items">
-                    <Button label="Go to Items" primary />
+                <Link href="/items" className="app-primary-link-button">
+                    Go to Items
                 </Link>
             </Box>
         );
@@ -121,8 +149,8 @@ export const ItemDetailView: React.FC = () => {
                     Item Not Found
                 </Heading>
                 <Text>The item you're looking for doesn't exist or has been deleted.</Text>
-                <Link href="/items">
-                    <Button label="Go to Items" primary />
+                <Link href="/items" className="app-primary-link-button">
+                    Go to Items
                 </Link>
             </Box>
         );
@@ -169,8 +197,9 @@ export const ItemDetailView: React.FC = () => {
         try {
             setIsSubmitting(true);
             setErrorMessage(undefined);
+            const returnPath = item.containerId !== undefined ? `/container/${item.containerId}` : '/items';
             await Items.deleteItem(item._id);
-            setLocation('/items');
+            setLocation(returnPath);
         } catch (error) {
             setErrorMessage(getErrorMessage(error));
         } finally {
@@ -193,7 +222,7 @@ export const ItemDetailView: React.FC = () => {
             <ItemDetailViewPresentation
                 item={item}
                 tags={tags}
-                containerPath={[]}
+                containerPath={containerPath}
                 onEdit={() => {
                     setErrorMessage(undefined);
                     setIsConfirmingDelete(false);
@@ -211,6 +240,9 @@ export const ItemDetailView: React.FC = () => {
                 }}
                 onRemoveTag={(tagId) => {
                     void handleRemoveTag(tagId);
+                }}
+                onNavigateToContainer={(containerId) => {
+                    setLocation(`/container/${containerId}`);
                 }}
                 disabled={isSubmitting}
             />

--- a/meteor-app/imports/ui/ItemDetailView.tsx
+++ b/meteor-app/imports/ui/ItemDetailView.tsx
@@ -36,6 +36,10 @@ const findInventoryItemById = (itemId: string): InventoryItem | undefined => {
     return InventoryItemsCollection.find({ _id: itemId }, { limit: 1 }).fetch()[0];
 };
 
+interface RouteItemDetailViewProps {
+    deleteReturnPath?: string;
+}
+
 /**
  * ItemDetailView - Route-aware wrapper that extracts itemId from URL parameters.
  *
@@ -57,7 +61,7 @@ const findInventoryItemById = (itemId: string): InventoryItem | undefined => {
  * </Route>
  * ```
  */
-export const ItemDetailView: React.FC = () => {
+export const ItemDetailView: React.FC<RouteItemDetailViewProps> = ({ deleteReturnPath }) => {
     const { itemId } = useParams<{ itemId: string }>();
     const [, setLocation] = useLocation();
     const [isEditing, setIsEditing] = useState(false);
@@ -197,7 +201,8 @@ export const ItemDetailView: React.FC = () => {
         try {
             setIsSubmitting(true);
             setErrorMessage(undefined);
-            const returnPath = item.containerId !== undefined ? `/container/${item.containerId}` : '/items';
+            const returnPath =
+                deleteReturnPath ?? (item.containerId !== undefined ? `/container/${item.containerId}` : '/items');
             await Items.deleteItem(item._id);
             setLocation(returnPath);
         } catch (error) {

--- a/meteor-app/imports/ui/ItemDetailViewPresentation.tsx
+++ b/meteor-app/imports/ui/ItemDetailViewPresentation.tsx
@@ -1,3 +1,8 @@
+/**
+ * Presentation-only item detail view.
+ * Renders item metadata, location breadcrumbs, tags, and detail actions while
+ * leaving data loading and routing decisions to container components.
+ */
 import { Box, Button, Heading, Text } from 'grommet';
 import { Edit, Trash, Up } from 'grommet-icons';
 import React from 'react';
@@ -103,7 +108,8 @@ export const ItemDetailViewPresentation: React.FC<ItemDetailViewProps> = ({
                                   }
                                 : undefined
                         }
-                        showHomeIcon
+                        showHomeIcon={false}
+                        lastCrumbIsCurrent={false}
                     />
                 </Box>
             )}

--- a/meteor-app/imports/ui/ItemForm.stories.tsx
+++ b/meteor-app/imports/ui/ItemForm.stories.tsx
@@ -253,7 +253,7 @@ export const TestSubmitBehavior: Story = {
     render: () => {
         const [submitData, setSubmitData] = useState<any>(null);
         const [submitCount, setSubmitCount] = useState(0);
-        const [errorMessage, setErrorMessage] = useState('');
+        const [errorMessage] = useState('');
         const [callLog, setCallLog] = useState<string[]>([]);
 
         return (

--- a/meteor-app/imports/ui/ItemsByTagView/ItemsByTagViewContainer.tsx
+++ b/meteor-app/imports/ui/ItemsByTagView/ItemsByTagViewContainer.tsx
@@ -1,13 +1,25 @@
-import { Box, Button, Heading, Text } from 'grommet';
+/**
+ * Route-backed tag filter container.
+ * Loads the selected tag and matching items from the URL while handling invalid tag fallbacks.
+ */
+import { Box, Heading, Text } from 'grommet';
 import React, { type ReactElement } from 'react';
 import { useParams, Link } from 'wouter';
 
-import { InventoryItemsCollection } from '/imports/api/items';
-import { TagsCollection } from '/imports/api/tags';
+import { InventoryItemsCollection, type InventoryItem } from '/imports/api/items';
+import { TagsCollection, type TagRecord } from '/imports/api/tags';
 import { LoadingState } from '/imports/ui/common/LoadingState';
 import { ItemsByTagViewPresentation } from '/imports/ui/ItemsByTagView/ItemsByTagViewPresentation';
 import { useSubscribe, useTracker } from '/imports/utility/reactMeteorData';
 import { usePageTitle } from '/imports/utility/usePageTitle';
+
+const findTagById = (tagId: string): TagRecord | undefined => {
+    return TagsCollection.find({ _id: tagId }, { limit: 1 }).fetch()[0];
+};
+
+const findInventoryItemById = (itemId: string): InventoryItem | undefined => {
+    return InventoryItemsCollection.find({ _id: itemId }, { limit: 1 }).fetch()[0];
+};
 
 /**
  * ItemsByTagViewContainer - Route-aware wrapper that extracts tagId from URL parameters.
@@ -28,14 +40,14 @@ export const ItemsByTagViewContainer = (): ReactElement => {
     const { tagId } = useParams<{ tagId: string }>();
 
     const isLoadingTags = useSubscribe('tags.all');
-    const isLoadingItems = useSubscribe('items.byTags', typeof tagId === 'string' && tagId !== '' ? [tagId] : []);
+    const isLoadingItems = useSubscribe('items.byTags', tagId !== '' ? [tagId] : []);
 
     usePageTitle('Tag Filter - My Inventory');
 
     // Fetch selected tag reactively
     const selectedTag = useTracker(() => {
         if (tagId === '') return undefined;
-        return TagsCollection.findOne({ _id: tagId });
+        return findTagById(tagId);
     }, [tagId]);
 
     // Fetch items with selected tag reactively
@@ -59,7 +71,7 @@ export const ItemsByTagViewContainer = (): ReactElement => {
 
         for (const item of items) {
             if (item.containerId !== undefined) {
-                const container = InventoryItemsCollection.findOne({ _id: item.containerId });
+                const container = findInventoryItemById(item.containerId);
                 if (container !== undefined) {
                     paths[item._id] = [{ _id: container._id, name: container.name }];
                 }
@@ -81,8 +93,8 @@ export const ItemsByTagViewContainer = (): ReactElement => {
                     Invalid Tag ID
                 </Heading>
                 <Text>The tag ID in the URL is missing or invalid.</Text>
-                <Link href="/tags">
-                    <Button label="Go to Tags" primary />
+                <Link href="/tags" className="app-primary-link-button">
+                    Go to Tags
                 </Link>
             </Box>
         );
@@ -96,8 +108,8 @@ export const ItemsByTagViewContainer = (): ReactElement => {
                     Tag Not Found
                 </Heading>
                 <Text>The tag you're looking for doesn't exist or has been deleted.</Text>
-                <Link href="/tags">
-                    <Button label="Go to Tags" primary />
+                <Link href="/tags" className="app-primary-link-button">
+                    Go to Tags
                 </Link>
             </Box>
         );

--- a/meteor-app/imports/ui/LongPressContextMenu.tsx
+++ b/meteor-app/imports/ui/LongPressContextMenu.tsx
@@ -1,3 +1,7 @@
+/**
+ * Touch-friendly long-press menu wrapper for mobile item actions.
+ * Handles gesture timing, cancellation, and menu dismissal while callers supply action content.
+ */
 import { Layer, Box } from 'grommet';
 import React, { type ReactElement, type ReactNode, useState, useRef, useEffect, useCallback } from 'react';
 import styled from 'styled-components';
@@ -142,7 +146,6 @@ export const LongPressContextMenu = ({
 }: LongPressContextMenuProps): ReactElement => {
     const [isPressed, setIsPressed] = useState(false);
     const [showMenu, setShowMenu] = useState(false);
-    const [menuPosition, setMenuPosition] = useState({ x: 0, y: 0 });
 
     const pressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const startPositionRef = useRef({ x: 0, y: 0 });
@@ -158,7 +161,6 @@ export const LongPressContextMenu = ({
             pressTimerRef.current = setTimeout(() => {
                 if (!hasMovedRef.current) {
                     setShowMenu(true);
-                    setMenuPosition({ x: clientX, y: clientY });
                     setIsPressed(false);
                     onMenuOpen?.();
 
@@ -213,6 +215,13 @@ export const LongPressContextMenu = ({
         [handleMenuClose]
     );
 
+    const handleContextMenu = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+        const nativeEvent = event.nativeEvent as PointerEvent;
+        if (nativeEvent.pointerType === 'touch' || nativeEvent.pointerType === 'pen') {
+            event.preventDefault();
+        }
+    }, []);
+
     // Cleanup timer on unmount
     useEffect(() => {
         return () => {
@@ -243,6 +252,7 @@ export const LongPressContextMenu = ({
             <Wrapper
                 $isPressed={isPressed}
                 onPointerDown={(e) => {
+                    if (e.button !== 0) return;
                     handlePressStart(e.clientX, e.clientY);
                 }}
                 onPointerMove={(e) => {
@@ -251,10 +261,7 @@ export const LongPressContextMenu = ({
                 onPointerUp={handlePressEnd}
                 onPointerCancel={handlePressEnd}
                 onPointerLeave={handlePressEnd}
-                onContextMenu={(e) => {
-                    // Prevent default context menu
-                    e.preventDefault();
-                }}
+                onContextMenu={handleContextMenu}
             >
                 {children}
             </Wrapper>

--- a/meteor-app/imports/ui/README.md
+++ b/meteor-app/imports/ui/README.md
@@ -59,13 +59,14 @@ export const ItemDetailView = (): ReactElement => {
 
 #### 1. Link Components (Preferred)
 
-Use `<Link>` from Wouter to wrap navigation elements:
+Use `<Link>` from Wouter as the navigation element. Do not wrap interactive elements such as Grommet
+`Button` inside a `Link`; that creates nested controls for assistive technology.
 
 ```typescript
 import { Link } from 'wouter';
 
-<Link href="/tags">
-    <Button label="Tags" />
+<Link href="/tags" className="app-primary-link-button">
+    Tags
 </Link>
 ```
 
@@ -137,8 +138,8 @@ const [selectedItemId, setSelectedItemId] = useState<string>();
 
 ```typescript
 // Navigation state is in URL, not React state
-<Link href="/tags">
-    <Button />
+<Link href="/tags" className="app-primary-link-button">
+    Tags
 </Link>
 ```
 

--- a/meteor-app/imports/ui/SearchResultsView.stories.tsx
+++ b/meteor-app/imports/ui/SearchResultsView.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import React from 'react';
 
 import type { InventoryItem } from '/imports/model/InventoryItem';
 

--- a/meteor-app/imports/utility/naturalSort.test.ts
+++ b/meteor-app/imports/utility/naturalSort.test.ts
@@ -1,0 +1,11 @@
+import assert from 'assert';
+
+import { compareNaturalText } from './naturalSort';
+
+describe('compareNaturalText', function () {
+    it('sorts numbered item and container labels naturally', function () {
+        const names = ['Cable 10', 'Box 10', 'Cable 2', 'Box 2'];
+
+        assert.deepStrictEqual(names.sort(compareNaturalText), ['Box 2', 'Box 10', 'Cable 2', 'Cable 10']);
+    });
+});

--- a/meteor-app/imports/utility/naturalSort.ts
+++ b/meteor-app/imports/utility/naturalSort.ts
@@ -1,0 +1,10 @@
+/**
+ * Natural text ordering for user-facing inventory names.
+ * Centralizes numeric collation so lists and selectors agree on labels like
+ * "Box 2" before "Box 10" without each component owning collator details.
+ */
+const naturalTextCollator = new Intl.Collator('en', { numeric: true, sensitivity: 'base' });
+
+export const compareNaturalText = (first: string, second: string): number => {
+    return naturalTextCollator.compare(first, second);
+};

--- a/meteor-app/server/test-helpers.ts
+++ b/meteor-app/server/test-helpers.ts
@@ -3,6 +3,8 @@
  * These methods are only available in development/test mode.
  */
 
+import type { IncomingMessage, ServerResponse } from 'http';
+
 import { Meteor } from 'meteor/meteor';
 import { WebApp } from 'meteor/webapp';
 
@@ -17,6 +19,15 @@ const HTTP_INTERNAL_SERVER_ERROR = 500;
 
 const TEST_RESET_ENABLED = process.env.E2E_RESET_DATABASE === '1';
 
+type TestHttpHandler = (req: IncomingMessage, res: ServerResponse) => void | Promise<void>;
+type WebAppWithHandlers = typeof WebApp & {
+    handlers: {
+        use: (path: string, handler: TestHttpHandler) => void;
+    };
+};
+
+const webAppWithHandlers = WebApp as WebAppWithHandlers;
+
 const isThrowawayMeteorMongoUrl = (mongoUrl: string): boolean => {
     try {
         const { hostname, pathname, port } = new URL(mongoUrl);
@@ -28,24 +39,27 @@ const isThrowawayMeteorMongoUrl = (mongoUrl: string): boolean => {
     }
 };
 
+const assertTestDatabaseMutationAllowed = (): void => {
+    if (Meteor.isProduction) {
+        throw new Meteor.Error('not-allowed', 'Cannot mutate test database in production');
+    }
+
+    if (!TEST_RESET_ENABLED) {
+        throw new Meteor.Error('not-allowed', 'Test database mutation is only enabled for explicit E2E test runs');
+    }
+
+    const mongoUrl = process.env.MONGO_URL;
+    if (mongoUrl !== undefined && mongoUrl !== '' && !isThrowawayMeteorMongoUrl(mongoUrl)) {
+        throw new Meteor.Error('not-allowed', 'Refusing to mutate a non-test Mongo database');
+    }
+};
+
 /**
  * Reset all collections to empty state.
  * WARNING: This deletes ALL data! Only use in test environments.
  */
 async function resetDatabase(): Promise<void> {
-    // Only allow in development mode
-    if (Meteor.isProduction) {
-        throw new Meteor.Error('not-allowed', 'Cannot reset database in production');
-    }
-
-    if (!TEST_RESET_ENABLED) {
-        throw new Meteor.Error('not-allowed', 'Database reset is only enabled for explicit E2E test runs');
-    }
-
-    const mongoUrl = process.env.MONGO_URL;
-    if (mongoUrl !== undefined && mongoUrl !== '' && !isThrowawayMeteorMongoUrl(mongoUrl)) {
-        throw new Meteor.Error('not-allowed', 'Refusing to reset a non-test Mongo database');
-    }
+    assertTestDatabaseMutationAllowed();
 
     // Remove all documents from all collections
     await Items.removeAsync({});
@@ -65,6 +79,24 @@ if (!Meteor.isProduction) {
         async 'test.resetDatabase'(): Promise<void> {
             await resetDatabase();
         },
+
+        async 'test.forceItemContainer'(itemId: string, containerId: string): Promise<number> {
+            assertTestDatabaseMutationAllowed();
+
+            if (itemId.trim() === '' || containerId.trim() === '') {
+                throw new Meteor.Error('invalid-argument', 'itemId and containerId are required');
+            }
+
+            return await Items.updateAsync(
+                { _id: itemId },
+                {
+                    $set: {
+                        containerId,
+                        modifiedAt: new Date(),
+                    },
+                }
+            );
+        },
     });
 
     /**
@@ -72,7 +104,7 @@ if (!Meteor.isProduction) {
      * This allows tests to reset without needing Meteor.call().
      * Only available in development mode.
      */
-    WebApp.connectHandlers.use('/api/test/reset-database', async (req, res) => {
+    webAppWithHandlers.handlers.use('/api/test/reset-database', async (req, res) => {
         // Only allow POST requests
         if (req.method !== 'POST') {
             res.writeHead(HTTP_METHOD_NOT_ALLOWED, { 'Content-Type': 'application/json' });

--- a/tests/e2e/app/app-smoke.spec.ts
+++ b/tests/e2e/app/app-smoke.spec.ts
@@ -1,10 +1,59 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { waitForMeteorReady, resetDatabase } from '../helpers/database';
 import { createItem } from '../helpers/factories';
 
 /**
  * Basic app smoke tests to verify the app loads and core navigation works.
  */
+
+const keyRoutesForNestedInteractiveAudit = [
+    '/',
+    '/items',
+    '/container/missing-container-id',
+    '/items/missing-item-id',
+    '/tags',
+    '/tags/missing-tag-id',
+    '/search',
+    '/settings/data',
+    '/does-not-exist',
+];
+
+const nestedInteractiveAuditViewports = [
+    { label: 'desktop', width: 1280, height: 800 },
+    { label: 'mobile', width: 390, height: 844 },
+];
+
+async function expectNoAnchorWrappedButtons(page: Page, context: string): Promise<void> {
+    const offenders = await page.locator('a button').evaluateAll((buttons) =>
+        buttons.map((button) => {
+            const anchor = button.closest('a');
+
+            return {
+                anchorHref: anchor?.getAttribute('href') ?? '',
+                buttonText: button.textContent?.trim() ?? '',
+                anchorHtml: anchor?.outerHTML.slice(0, 300) ?? '',
+            };
+        })
+    );
+
+    expect(offenders, `${context} should not render buttons inside anchors`).toEqual([]);
+}
+
+async function focusHrefWithKeyboard(page: Page, href: string): Promise<void> {
+    for (let tabCount = 0; tabCount < 30; tabCount += 1) {
+        if (
+            await page.evaluate((expectedHref) => {
+                return document.activeElement?.getAttribute('href') === expectedHref;
+            }, href)
+        ) {
+            return;
+        }
+
+        await page.keyboard.press('Tab');
+    }
+
+    throw new Error(`Could not focus link with href "${href}" using keyboard navigation`);
+}
 
 test.beforeEach(async ({ page }) => {
     // Navigate to app and wait for Meteor to be ready
@@ -19,19 +68,39 @@ test.describe('App Smoke Tests', () => {
     test('should load the app homepage', async ({ page }) => {
         await page.goto('/');
 
-        // Should show app header
-        await expect(page.getByRole('heading', { name: 'Inventory App' })).toBeVisible();
+        // Should show app header without adding a competing heading before the page title
+        await expect(page.getByText('Inventory App', { exact: true })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Inventory App' })).toHaveCount(0);
 
-        // Should show navigation tabs
-        await expect(page.getByRole('button', { name: 'Items' })).toBeVisible();
-        await expect(page.getByRole('button', { name: 'Tags' })).toBeVisible();
+        // Should show navigation tabs as links, not nested interactive link-button pairs
+        const desktopNav = page.getByRole('navigation', { name: 'Desktop primary navigation' });
+        await expect(desktopNav.getByRole('link', { name: 'Items' })).toBeVisible();
+        await expect(desktopNav.getByRole('link', { name: 'Tags' })).toBeVisible();
+        await expect(desktopNav.locator('a button')).toHaveCount(0);
+    });
+
+    test('home page should not duplicate the Items nav label as a page heading', async ({ page }) => {
+        await page.goto('/');
+
+        const visibleItemsLabels = page
+            .getByRole('link', { name: 'Items', exact: true })
+            .or(page.getByRole('heading', { name: 'Items', exact: true }));
+
+        await expect(page.getByRole('heading', { name: 'All Items', exact: true })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Items', exact: true })).toHaveCount(0);
+        await expect(visibleItemsLabels).toHaveCount(1);
+
+        await page.setViewportSize({ width: 390, height: 844 });
+        await expect(page.getByRole('heading', { name: 'All Items', exact: true })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Items', exact: true })).toHaveCount(0);
+        await expect(visibleItemsLabels).toHaveCount(1);
     });
 
     test('should navigate between Items and Tags views', async ({ page }) => {
         await page.goto('/');
 
-        // Default view should be Items
-        await expect(page.getByRole('heading', { name: 'Items' })).toBeVisible();
+        // Default view should be All Items to avoid duplicating the nav label
+        await expect(page.getByRole('heading', { name: 'All Items', exact: true })).toBeVisible();
         await expect(page.getByRole('button', { name: 'Create Item' })).toBeVisible();
 
         const desktopNav = page.getByRole('navigation', { name: 'Desktop primary navigation' });
@@ -39,7 +108,7 @@ test.describe('App Smoke Tests', () => {
         await expect(desktopNav.getByRole('link', { name: 'Items' })).toHaveAttribute('aria-current', 'page');
 
         // Click Tags tab
-        await page.getByRole('button', { name: 'Tags' }).click();
+        await desktopNav.getByRole('link', { name: 'Tags' }).click();
 
         // Should show tags view (AllTagsView component)
         // Note: Need to check what's actually rendered in AllTagsView
@@ -47,26 +116,137 @@ test.describe('App Smoke Tests', () => {
         await expect(desktopNav.getByRole('link', { name: 'Tags' })).toHaveAttribute('aria-current', 'page');
 
         // Click back to Items tab
-        await page.getByRole('button', { name: 'Items' }).click();
+        await desktopNav.getByRole('link', { name: 'Items' }).click();
 
         // Should be back to items view
-        await expect(page.getByRole('heading', { name: 'Items' })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'All Items', exact: true })).toBeVisible();
+    });
+
+    test('fallback navigation links are semantic links', async ({ page }) => {
+        await page.goto('/items/missing-item-id');
+        await waitForMeteorReady(page);
+        await expect(page.getByRole('heading', { name: 'Item Not Found' })).toBeVisible();
+        await expect(page.getByRole('link', { name: 'Go to Items' })).toBeVisible();
+        await expect(page.locator('a button')).toHaveCount(0);
+
+        await page.goto('/tags/missing-tag-id');
+        await waitForMeteorReady(page);
+        await expect(page.getByRole('heading', { name: 'Tag Not Found' })).toBeVisible();
+        await expect(page.getByRole('link', { name: 'Go to Tags' })).toBeVisible();
+        await expect(page.locator('a button')).toHaveCount(0);
+    });
+
+    test('key routes do not render buttons inside anchors', async ({ page }) => {
+        test.setTimeout(60_000);
+
+        for (const viewport of nestedInteractiveAuditViewports) {
+            await page.setViewportSize({ width: viewport.width, height: viewport.height });
+
+            for (const route of keyRoutesForNestedInteractiveAudit) {
+                await page.goto(route);
+                await waitForMeteorReady(page);
+                await expectNoAnchorWrappedButtons(page, `${viewport.label} ${route}`);
+            }
+        }
     });
 
     test('should navigate back to root after opening a top-level container', async ({ page }) => {
-        await page.goto('/');
-        await createItem(page, {
+        const containerId = await createItem(page, {
             name: 'Regression Room',
             isContainer: true,
         });
+        await page.goto('/items');
+        await waitForMeteorReady(page);
 
-        await page.getByText('Regression Room').click();
+        await page.getByTestId('items-list').getByText('Regression Room').click();
         const rootBreadcrumb = page.getByRole('button', { name: 'Navigate to all items' });
+        await expect(page).toHaveURL(new RegExp(`/container/${containerId}$`));
         await expect(rootBreadcrumb).toBeVisible();
-        await expect(page.getByText('Regression Room')).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Regression Room' })).toBeVisible();
+        await expect(
+            page.getByRole('navigation', { name: 'Desktop primary navigation' }).getByRole('link', { name: 'Items' })
+        ).toHaveAttribute('aria-current', 'page');
 
+        await page.goBack();
+        await expect(page).toHaveURL(/\/items$/);
+        await expect(page.getByTestId('items-list').getByText('Regression Room')).toBeVisible();
+
+        await page.getByTestId('items-list').getByText('Regression Room').click();
+        await expect(page).toHaveURL(new RegExp(`/container/${containerId}$`));
         await rootBreadcrumb.click();
-        await expect(page.getByText('Regression Room')).toBeVisible();
+        await expect(page).toHaveURL(/\/items$/);
+        await expect(page.getByRole('heading', { name: 'All Items', exact: true })).toBeVisible();
+        await expect(page.getByTestId('items-list').getByText('Regression Room')).toBeVisible();
+
+        await page.goBack();
+        await expect(page).toHaveURL(new RegExp(`/container/${containerId}$`));
+        await expect(page.getByRole('heading', { name: 'Regression Room' })).toBeVisible();
+    });
+
+    test('items and containers expose semantic links with keyboard navigation', async ({ page }) => {
+        const containerId = await createItem(page, {
+            name: 'Accessible Room',
+            isContainer: true,
+        });
+        const itemId = await createItem(page, {
+            name: 'Accessible Lamp',
+        });
+
+        await page.goto('/');
+        await waitForMeteorReady(page);
+
+        const containerLink = page.getByRole('link', { name: 'Open container Accessible Room' });
+        const itemLink = page.getByRole('link', { name: 'View item Accessible Lamp' });
+
+        await expect(containerLink).toBeVisible();
+        await expect(containerLink).toHaveAttribute('href', `/container/${containerId}`);
+        await expect(itemLink).toBeVisible();
+        await expect(itemLink).toHaveAttribute('href', `/items/${itemId}`);
+
+        const containerContextMenuWasNotCanceled = await containerLink.evaluate((element) =>
+            element.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, button: 2, cancelable: true }))
+        );
+        const itemContextMenuWasNotCanceled = await itemLink.evaluate((element) =>
+            element.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, button: 2, cancelable: true }))
+        );
+        expect(containerContextMenuWasNotCanceled).toBe(true);
+        expect(itemContextMenuWasNotCanceled).toBe(true);
+
+        const itemHref = `/items/${itemId}`;
+        await focusHrefWithKeyboard(page, itemHref);
+        await expect(page.locator(`a[href="${itemHref}"]`)).toBeFocused();
+        await page.keyboard.press('Enter');
+        await expect(page).toHaveURL(new RegExp(`/items/${itemId}$`));
+        await expect(page.getByRole('heading', { name: 'Accessible Lamp' })).toBeVisible();
+
+        await page.goto('/');
+        await waitForMeteorReady(page);
+
+        const reloadedContainerLink = page.getByRole('link', { name: 'Open container Accessible Room' });
+        const containerHref = `/container/${containerId}`;
+        await focusHrefWithKeyboard(page, containerHref);
+        await expect(page.locator(`a[href="${containerHref}"]`)).toBeFocused();
+        await page.keyboard.press('Enter');
+        await expect(page).toHaveURL(new RegExp(`/container/${containerId}$`));
+        await expect(page.getByRole('button', { name: 'Navigate to all items' })).toBeVisible();
+    });
+
+    test('should deep-link directly to a container view', async ({ page }) => {
+        const containerId = await createItem(page, {
+            name: 'Deep Link Room',
+            isContainer: true,
+        });
+        await createItem(page, {
+            name: 'Deep Link Lamp',
+            containerId,
+        });
+
+        await page.goto(`/container/${containerId}`);
+        await waitForMeteorReady(page);
+
+        await expect(page).toHaveURL(new RegExp(`/container/${containerId}$`));
+        await expect(page.getByText('Deep Link Lamp')).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Navigate to all items' })).toBeVisible();
     });
 
     test('should provide touch-friendly mobile bottom navigation without horizontal overflow', async ({ page }) => {
@@ -93,7 +273,7 @@ test.describe('App Smoke Tests', () => {
         }
 
         await mobileNav.getByRole('link', { name: 'Items' }).click();
-        await expect(page.getByRole('heading', { name: 'Items' })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'All Items', exact: true })).toBeVisible();
 
         await mobileNav.getByRole('link', { name: 'Tags' }).click();
         await expect(page.getByRole('heading', { name: 'Tags' })).toBeVisible();
@@ -132,5 +312,28 @@ test.describe('App Smoke Tests', () => {
 
         // Modal should be closed
         await expect(page.getByRole('heading', { name: 'Create New Item' })).not.toBeVisible();
+    });
+
+    test('should close Create Item modal on route change', async ({ page }) => {
+        await page.goto('/search');
+        await waitForMeteorReady(page);
+        await expect(page.getByRole('heading', { name: 'Search' })).toBeVisible();
+
+        await page
+            .getByRole('navigation', { name: 'Desktop primary navigation' })
+            .getByRole('link', { name: 'Items' })
+            .click();
+        await expect(page).toHaveURL(/\/items$/);
+        await expect(page.getByRole('heading', { name: 'All Items', exact: true })).toBeVisible();
+
+        await page.getByRole('button', { name: 'Create Item' }).click();
+        await expect(page.getByRole('heading', { name: 'Create New Item' })).toBeVisible();
+
+        await page.goBack();
+
+        await expect(page).toHaveURL(/\/search$/);
+        await expect(page.getByRole('heading', { name: 'Create New Item' })).toHaveCount(0);
+        await expect(page.locator('input[name="name"]')).toHaveCount(0);
+        await expect(page.getByRole('heading', { name: 'Search' })).toBeVisible();
     });
 });

--- a/tests/e2e/app/item-detail-routing.spec.ts
+++ b/tests/e2e/app/item-detail-routing.spec.ts
@@ -1,0 +1,263 @@
+import { expect, test } from '@playwright/test';
+
+import { callMeteorMethod, resetDatabase, waitForMeteorReady } from '../helpers/database';
+import { createItem, createTag } from '../helpers/factories';
+
+test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForMeteorReady(page);
+    await resetDatabase(page);
+    await page.reload({ waitUntil: 'networkidle' });
+    await waitForMeteorReady(page);
+    await expect(page.getByRole('heading', { name: 'All Items', exact: true })).toBeVisible();
+});
+
+test.describe('Item detail routing', () => {
+    test('updates the URL when opening an item from the list', async ({ page }) => {
+        const itemId = await createItem(page, {
+            name: 'Route Backed Lamp',
+            description: 'List click should become a shareable route',
+        });
+
+        await page.goto('/items');
+        await waitForMeteorReady(page);
+
+        const itemLink = page.getByRole('link', { name: 'View item Route Backed Lamp' });
+        await expect(itemLink).toBeVisible();
+        await expect(itemLink).toHaveAttribute('href', `/items/${itemId}`);
+
+        await itemLink.click();
+
+        await expect(page).toHaveURL(new RegExp(`/items/${itemId}$`));
+        await expect(page.getByRole('heading', { name: 'Route Backed Lamp' })).toBeVisible();
+        await expect(page.getByText('List click should become a shareable route')).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Item Details' })).toHaveCount(0);
+    });
+
+    test('renders item details from a direct item URL', async ({ page }) => {
+        const containerId = await createItem(page, {
+            name: 'Direct Link Cabinet',
+            isContainer: true,
+        });
+        const itemId = await createItem(page, {
+            name: 'Direct Link Flashlight',
+            description: 'Direct routes should render without prior list state',
+            containerId,
+        });
+
+        await page.goto(`/items/${itemId}`);
+        await waitForMeteorReady(page);
+
+        await expect(page).toHaveURL(new RegExp(`/items/${itemId}$`));
+        await expect(page.getByRole('heading', { name: 'Direct Link Flashlight' })).toBeVisible();
+        await expect(page.getByText('Direct routes should render without prior list state')).toBeVisible();
+        await expect(page.getByText('Location:')).toBeVisible();
+        await expect(page.getByText('Direct Link Cabinet', { exact: true })).toBeVisible();
+    });
+
+    test('returns to the containing container after deleting a nested route-backed item', async ({ page }) => {
+        const containerId = await createItem(page, {
+            name: 'Return Cabinet',
+            isContainer: true,
+        });
+        const itemId = await createItem(page, {
+            name: 'Return Battery',
+            containerId,
+        });
+
+        await page.goto(`/items/${itemId}`);
+        await waitForMeteorReady(page);
+
+        await expect(page.getByRole('heading', { name: 'Return Battery' })).toBeVisible();
+        await page
+            .getByRole('button', { name: /delete/i })
+            .first()
+            .click();
+        await expect(page.getByRole('heading', { name: 'Delete Item' })).toBeVisible();
+        await page.getByRole('button', { name: /delete item/i }).click();
+
+        await expect(page).toHaveURL(new RegExp(`/container/${containerId}$`));
+        await expect(page.getByRole('heading', { name: 'Return Cabinet' })).toBeVisible();
+        await expect(page.getByText('No items at this level')).toBeVisible();
+        await expect(page.getByText('Return Battery', { exact: true })).toHaveCount(0);
+    });
+
+    test('returns to the items list after deleting a root route-backed item', async ({ page }) => {
+        const itemId = await createItem(page, {
+            name: 'Return Root Item',
+        });
+
+        await page.goto(`/items/${itemId}`);
+        await waitForMeteorReady(page);
+
+        await expect(page.getByRole('heading', { name: 'Return Root Item' })).toBeVisible();
+        await page
+            .getByRole('button', { name: /delete/i })
+            .first()
+            .click();
+        await expect(page.getByRole('heading', { name: 'Delete Item' })).toBeVisible();
+        await page.getByRole('button', { name: /delete item/i }).click();
+
+        await expect(page).toHaveURL(/\/items$/);
+        await expect(page.getByRole('heading', { name: 'All Items', exact: true })).toBeVisible();
+        await expect(page.getByText('Return Root Item', { exact: true })).toHaveCount(0);
+    });
+
+    test('shows a not-found state for missing and deleted container routes', async ({ page }) => {
+        await page.goto('/container/missing-container-id');
+        await waitForMeteorReady(page);
+
+        await expect(page.getByRole('heading', { name: 'Container Not Found' })).toBeVisible();
+        await expect(page.getByText(/doesn't exist, is not a container, or has been deleted/)).toBeVisible();
+        await expect(page.getByRole('link', { name: 'Go to Items' })).toHaveAttribute('href', '/items');
+        await expect(page.getByText('No items at this level')).toHaveCount(0);
+
+        const deletedContainerId = await createItem(page, {
+            name: 'Deleted Container Route',
+            isContainer: true,
+        });
+        await callMeteorMethod<number>(page, 'deleteItem', deletedContainerId);
+
+        await page.goto(`/container/${deletedContainerId}`);
+        await waitForMeteorReady(page);
+
+        await expect(page.getByRole('heading', { name: 'Container Not Found' })).toBeVisible();
+        await expect(page.getByText('Deleted Container Route', { exact: true })).toHaveCount(0);
+        await expect(page.getByText('No items at this level')).toHaveCount(0);
+    });
+
+    test('preserves scoped search context after opening a result and going back', async ({ page }) => {
+        const containerId = await createItem(page, {
+            name: 'Scoped Search Cabinet',
+            isContainer: true,
+        });
+        const firstScopedItemId = await createItem(page, {
+            name: 'Scoped Wrench',
+            containerId,
+        });
+        await createItem(page, {
+            name: 'Global Wrench',
+        });
+        await createItem(page, {
+            name: 'Scoped Spare Filter',
+            containerId,
+        });
+        await createItem(page, {
+            name: 'Global Spare Filter',
+        });
+
+        await page.goto(`/container/${containerId}`);
+        await waitForMeteorReady(page);
+        await page
+            .getByRole('navigation', { name: 'Desktop primary navigation' })
+            .getByRole('link', { name: 'Search' })
+            .click();
+
+        const scopedSearchButton = page.getByRole('button', { name: 'Scoped search', exact: true });
+
+        await scopedSearchButton.click();
+        await expect(scopedSearchButton).toHaveAttribute('aria-pressed', 'true');
+        await expect(scopedSearchButton).toContainText('Scoped Search Cabinet');
+
+        await page.getByRole('textbox', { name: 'Search query' }).fill('Wrench');
+        await page.getByRole('button', { name: 'Submit search' }).click();
+
+        const scopedWrenchResult = page.locator('button').filter({ hasText: 'Scoped Wrench' }).first();
+        await expect(scopedWrenchResult).toBeVisible();
+        await expect(page.locator('button').filter({ hasText: 'Global Wrench' })).toHaveCount(0);
+
+        await scopedWrenchResult.click();
+        await expect(page).toHaveURL(new RegExp(`/items/${firstScopedItemId}$`));
+        await expect(page.getByRole('heading', { name: 'Scoped Wrench' })).toBeVisible();
+
+        await page.goBack();
+        await expect(page).toHaveURL(/\/search$/);
+        await expect(scopedSearchButton).toHaveAttribute('aria-pressed', 'true');
+        await expect(scopedSearchButton).toContainText('Scoped Search Cabinet');
+
+        await page.getByRole('button', { name: 'Clear search' }).click();
+        await page.getByRole('textbox', { name: 'Search query' }).fill('Spare Filter');
+        await page.getByRole('button', { name: 'Submit search' }).click();
+
+        await expect(page.locator('button').filter({ hasText: 'Scoped Spare Filter' })).toBeVisible();
+        await expect(page.locator('button').filter({ hasText: 'Global Spare Filter' })).toHaveCount(0);
+    });
+
+    test('does not reuse stale scoped context after direct item-detail navigation', async ({ page }) => {
+        const containerId = await createItem(page, {
+            name: 'Prior Scope Cabinet',
+            isContainer: true,
+        });
+        await createItem(page, {
+            name: 'Scoped Socket Set',
+            containerId,
+        });
+        await createItem(page, {
+            name: 'Global Socket Set',
+        });
+        const directItemId = await createItem(page, {
+            name: 'Direct Detail Compass',
+        });
+
+        await page.goto(`/container/${containerId}`);
+        await waitForMeteorReady(page);
+        await page
+            .getByRole('navigation', { name: 'Desktop primary navigation' })
+            .getByRole('link', { name: 'Search' })
+            .click();
+
+        const scopedSearchButton = page.getByRole('button', { name: 'Scoped search', exact: true });
+
+        await scopedSearchButton.click();
+        await expect(scopedSearchButton).toHaveAttribute('aria-pressed', 'true');
+        await expect(scopedSearchButton).toContainText('Prior Scope Cabinet');
+
+        await page.getByRole('textbox', { name: 'Search query' }).fill('Socket Set');
+        await page.getByRole('button', { name: 'Submit search' }).click();
+
+        await expect(page.locator('button').filter({ hasText: 'Scoped Socket Set' })).toBeVisible();
+        await expect(page.locator('button').filter({ hasText: 'Global Socket Set' })).toHaveCount(0);
+
+        await page.goto(`/items/${directItemId}`);
+        await waitForMeteorReady(page);
+        await expect(page.getByRole('heading', { name: 'Direct Detail Compass' })).toBeVisible();
+
+        await page.goto('/search');
+        await waitForMeteorReady(page);
+
+        await expect(page.getByRole('button', { name: 'Global search', exact: true })).toHaveAttribute(
+            'aria-pressed',
+            'true'
+        );
+        await expect(page.getByRole('button', { name: 'Scoped search unavailable' })).toBeDisabled();
+
+        await page.getByRole('textbox', { name: 'Search query' }).fill('Socket Set');
+        await page.getByRole('button', { name: 'Submit search' }).click();
+
+        await expect(page.locator('button').filter({ hasText: 'Scoped Socket Set' }).first()).toBeVisible();
+        await expect(page.locator('button').filter({ hasText: 'Global Socket Set' }).first()).toBeVisible();
+    });
+
+    test('removes a tag from route-backed item details', async ({ page }) => {
+        const tagId = await createTag(page, {
+            name: 'Route Detail Tag',
+        });
+        const itemId = await createItem(page, {
+            name: 'Tagged Route Item',
+            tagIds: [tagId],
+        });
+
+        await page.goto(`/items/${itemId}`);
+        await waitForMeteorReady(page);
+
+        await expect(page.getByRole('heading', { name: 'Tagged Route Item' })).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Remove Route Detail Tag tag' })).toBeVisible();
+
+        await page.getByRole('button', { name: 'Remove Route Detail Tag tag' }).click();
+        await expect(page.getByRole('button', { name: 'Remove Route Detail Tag tag' })).toHaveCount(0);
+
+        await page.reload({ waitUntil: 'networkidle' });
+        await waitForMeteorReady(page);
+        await expect(page.getByRole('button', { name: 'Remove Route Detail Tag tag' })).toHaveCount(0);
+    });
+});

--- a/tests/e2e/app/item-detail-routing.spec.ts
+++ b/tests/e2e/app/item-detail-routing.spec.ts
@@ -69,10 +69,7 @@ test.describe('Item detail routing', () => {
         await waitForMeteorReady(page);
 
         await expect(page.getByRole('heading', { name: 'Return Battery' })).toBeVisible();
-        await page
-            .getByRole('button', { name: /delete/i })
-            .first()
-            .click();
+        await page.getByRole('button', { name: /Delete$/ }).click();
         await expect(page.getByRole('heading', { name: 'Delete Item' })).toBeVisible();
         await page.getByRole('button', { name: /delete item/i }).click();
 
@@ -91,10 +88,7 @@ test.describe('Item detail routing', () => {
         await waitForMeteorReady(page);
 
         await expect(page.getByRole('heading', { name: 'Return Root Item' })).toBeVisible();
-        await page
-            .getByRole('button', { name: /delete/i })
-            .first()
-            .click();
+        await page.getByRole('button', { name: /Delete$/ }).click();
         await expect(page.getByRole('heading', { name: 'Delete Item' })).toBeVisible();
         await page.getByRole('button', { name: /delete item/i }).click();
 
@@ -181,6 +175,54 @@ test.describe('Item detail routing', () => {
 
         await expect(page.locator('button').filter({ hasText: 'Scoped Spare Filter' })).toBeVisible();
         await expect(page.locator('button').filter({ hasText: 'Global Spare Filter' })).toHaveCount(0);
+    });
+
+    test('returns to scoped search after deleting a search result detail', async ({ page }) => {
+        const containerId = await createItem(page, {
+            name: 'Search Delete Cabinet',
+            isContainer: true,
+        });
+        const itemId = await createItem(page, {
+            name: 'Scoped Delete Target',
+            containerId,
+        });
+        await createItem(page, {
+            name: 'Global Delete Target',
+        });
+
+        await page.goto(`/container/${containerId}`);
+        await waitForMeteorReady(page);
+        await page
+            .getByRole('navigation', { name: 'Desktop primary navigation' })
+            .getByRole('link', { name: 'Search' })
+            .click();
+
+        const scopedSearchButton = page.getByRole('button', { name: 'Scoped search', exact: true });
+
+        await scopedSearchButton.click();
+        await expect(scopedSearchButton).toHaveAttribute('aria-pressed', 'true');
+        await expect(scopedSearchButton).toContainText('Search Delete Cabinet');
+
+        await page.getByRole('textbox', { name: 'Search query' }).fill('Delete Target');
+        await page.getByRole('button', { name: 'Submit search' }).click();
+
+        const scopedDeleteResult = page.locator('button').filter({ hasText: 'Scoped Delete Target' }).first();
+        await expect(scopedDeleteResult).toBeVisible();
+        await expect(page.locator('button').filter({ hasText: 'Global Delete Target' })).toHaveCount(0);
+
+        await scopedDeleteResult.click();
+        await expect(page).toHaveURL(new RegExp(`/items/${itemId}$`));
+        await expect(page.getByRole('heading', { name: 'Scoped Delete Target' })).toBeVisible();
+
+        await page.getByRole('button', { name: /Delete$/ }).click();
+        await expect(page.getByRole('heading', { name: 'Delete Item' })).toBeVisible();
+        await page.getByRole('button', { name: /delete item/i }).click();
+
+        await expect(page).toHaveURL(/\/search$/);
+        await expect(page.getByRole('heading', { name: 'Search' })).toBeVisible();
+        await expect(page.getByRole('textbox', { name: 'Search query' })).toHaveValue('Delete Target');
+        await expect(scopedSearchButton).toHaveAttribute('aria-pressed', 'true');
+        await expect(scopedSearchButton).toContainText('Search Delete Cabinet');
     });
 
     test('does not reuse stale scoped context after direct item-detail navigation', async ({ page }) => {

--- a/tests/e2e/app/item-maintenance.spec.ts
+++ b/tests/e2e/app/item-maintenance.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import { createItem, createTag } from '../helpers/factories';
-import { resetDatabase, waitForMeteorReady } from '../helpers/database';
+import { callMeteorMethod, resetDatabase, waitForMeteorReady } from '../helpers/database';
 
 test.beforeEach(async ({ page }) => {
     await page.goto('/');
@@ -41,6 +41,74 @@ test.describe('Item maintenance happy paths', () => {
         await expect(page.getByText('Updated Tent', { exact: true })).toBeVisible();
     });
 
+    test('shows nested item location breadcrumbs on direct item links', async ({ page }) => {
+        const rootContainerId = await createItem(page, {
+            name: 'Maintenance Room',
+            isContainer: true,
+        });
+        const shelfId = await createItem(page, {
+            name: 'Maintenance Shelf',
+            isContainer: true,
+            containerId: rootContainerId,
+        });
+        const itemId = await createItem(page, {
+            name: 'Nested Maintenance Item',
+            containerId: shelfId,
+        });
+
+        await page.goto(`/items/${itemId}`);
+        await waitForMeteorReady(page);
+
+        await expect(page.getByRole('heading', { name: 'Nested Maintenance Item' })).toBeVisible();
+        await expect(page.getByText('Location:')).toBeVisible();
+        await expect(page.getByText('Maintenance Room', { exact: true })).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Navigate to Maintenance Room' })).toBeVisible();
+        await expect(page.getByText('Maintenance Shelf', { exact: true })).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Navigate to Maintenance Shelf' })).toBeVisible();
+
+        await page.getByRole('button', { name: 'Navigate to Maintenance Shelf' }).click();
+        await expect(page).toHaveURL(new RegExp(`/container/${shelfId}$`));
+        await expect(page.getByText('Nested Maintenance Item', { exact: true })).toBeVisible();
+    });
+
+    test('keeps direct item breadcrumbs finite when container ancestry is cyclic', async ({ page }) => {
+        const parentId = await createItem(page, {
+            name: 'Cycle Parent',
+            isContainer: true,
+        });
+        const childId = await createItem(page, {
+            name: 'Cycle Child',
+            isContainer: true,
+            containerId: parentId,
+        });
+        const itemId = await createItem(page, {
+            name: 'Cycle Guard Item',
+            containerId: childId,
+        });
+
+        const forcedContainerUpdateCount = await callMeteorMethod<number>(
+            page,
+            'test.forceItemContainer',
+            parentId,
+            childId
+        );
+        expect(forcedContainerUpdateCount).toBe(1);
+
+        await page.goto(`/items/${itemId}`);
+        await waitForMeteorReady(page);
+
+        await expect(page.getByRole('heading', { name: 'Cycle Guard Item' })).toBeVisible();
+        await expect(page.getByText('Location:')).toBeVisible();
+        await expect(page.getByText('Cycle Parent', { exact: true })).toHaveCount(1);
+        await expect(page.getByText('Cycle Child', { exact: true })).toHaveCount(1);
+        await expect(page.getByRole('button', { name: 'Navigate to Cycle Parent' })).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Navigate to Cycle Child' })).toBeVisible();
+
+        await page.getByRole('button', { name: 'Navigate to Cycle Child' }).click();
+        await expect(page).toHaveURL(new RegExp(`/container/${childId}$`));
+        await expect(page.getByText('Cycle Guard Item', { exact: true })).toBeVisible();
+    });
+
     test('filters descendant containers out of move targets', async ({ page }) => {
         const parentId = await createItem(page, { name: 'Parent Container', isContainer: true });
         const childId = await createItem(page, {
@@ -64,7 +132,7 @@ test.describe('Item maintenance happy paths', () => {
         await expect(page.getByText('Grandchild Container', { exact: true })).not.toBeVisible();
     });
 
-    test('filters descendant containers out of search result modal move targets', async ({ page }) => {
+    test('filters descendant containers out of search result detail move targets', async ({ page }) => {
         const parentId = await createItem(page, { name: 'Parent Container', isContainer: true });
         const childId = await createItem(page, {
             name: 'Child Container',
@@ -84,7 +152,7 @@ test.describe('Item maintenance happy paths', () => {
         await page.getByRole('button', { name: 'Submit search' }).click();
         await page.locator('button').filter({ hasText: 'Parent Container' }).first().click();
 
-        await expect(page.getByRole('heading', { name: 'Item Details' })).toBeVisible();
+        await expect(page).toHaveURL(new RegExp(`/items/${parentId}$`));
         await page.getByRole('button', { name: /Move$/ }).click();
 
         await expect(page.getByText('Root (No Container)', { exact: true })).toBeVisible();

--- a/tests/e2e/app/items-and-tags.spec.ts
+++ b/tests/e2e/app/items-and-tags.spec.ts
@@ -8,7 +8,7 @@ test.beforeEach(async ({ page }) => {
     await resetDatabase(page);
     await page.reload({ waitUntil: 'networkidle' });
     await waitForMeteorReady(page);
-    await expect(page.getByRole('heading', { name: 'Items' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'All Items', exact: true })).toBeVisible();
 });
 
 const getListItemLocator = (page: Page, text: string) => {
@@ -22,7 +22,82 @@ const reloadAndWait = async (page: Page): Promise<void> => {
     await page.waitForSelector('text=Inventory App');
 };
 
+const expectItemNameToBeTruncated = async (page: Page, name: string): Promise<void> => {
+    const rowLink = page.getByRole('link', { name: `View item ${name}` });
+    await expect(rowLink).toBeVisible();
+
+    const nameText = rowLink.getByText(name, { exact: true });
+    const metrics = await nameText.evaluate((element) => {
+        const textElement = element as HTMLElement;
+        const rowElement = textElement.closest('a') as HTMLElement | null;
+        const textStyle = window.getComputedStyle(textElement);
+        const textRect = textElement.getBoundingClientRect();
+        const rowRect = rowElement?.getBoundingClientRect();
+
+        return {
+            bodyClientWidth: document.documentElement.clientWidth,
+            bodyScrollWidth: document.documentElement.scrollWidth,
+            rowRight: rowRect?.right ?? 0,
+            textClientWidth: textElement.clientWidth,
+            textOverflow: textStyle.textOverflow,
+            textRight: textRect.right,
+            textScrollWidth: textElement.scrollWidth,
+            whiteSpace: textStyle.whiteSpace,
+        };
+    });
+
+    expect(metrics.bodyScrollWidth).toBeLessThanOrEqual(metrics.bodyClientWidth);
+    expect(metrics.textRight).toBeLessThanOrEqual(metrics.rowRight + 1);
+    expect(metrics.textScrollWidth).toBeGreaterThan(metrics.textClientWidth);
+    expect(metrics.textOverflow).toBe('ellipsis');
+    expect(metrics.whiteSpace).toBe('nowrap');
+};
+
 test.describe('Items view', () => {
+    test('sorts containers and items naturally by number', async ({ page }) => {
+        await callMeteorMethod<string>(page, 'createItem', {
+            name: 'Cable 10',
+        });
+        await callMeteorMethod<string>(page, 'createItem', {
+            name: 'Box 10',
+            isContainer: true,
+        });
+        await callMeteorMethod<string>(page, 'createItem', {
+            name: 'Cable 2',
+        });
+        await callMeteorMethod<string>(page, 'createItem', {
+            name: 'Box 2',
+            isContainer: true,
+        });
+
+        await reloadAndWait(page);
+
+        await expect(page.getByTestId('items-list').getByRole('link')).toHaveText([
+            'Box 2',
+            'Box 10',
+            'Cable 2',
+            'Cable 10',
+        ]);
+    });
+
+    test('truncates very long item names at desktop and mobile widths', async ({ page }) => {
+        const longItemName =
+            'A very long item name that exceeds typical lengths and should be truncated by the UI to verify that text overflow behavior is working correctly across item list viewports, desktop screenshots, and narrow mobile screens without creating horizontal scrolling';
+
+        await callMeteorMethod<string>(page, 'createItem', {
+            name: longItemName,
+        });
+
+        for (const viewport of [
+            { width: 1280, height: 720 },
+            { width: 390, height: 844 },
+        ]) {
+            await page.setViewportSize(viewport);
+            await reloadAndWait(page);
+            await expectItemNameToBeTruncated(page, longItemName);
+        }
+    });
+
     test('creates container and standard items via the UI', async ({ page }) => {
         const containerName = `Container ${Date.now()}`;
         const itemName = `Item ${Date.now()}`;
@@ -109,25 +184,34 @@ test.describe('Items view', () => {
 
         await expect(getListItemLocator(page, rootContainerName)).toBeVisible();
         await getListItemLocator(page, rootContainerName).click();
+        await expect(page).toHaveURL(new RegExp(`/container/${rootContainerId}$`));
         await expect(getListItemLocator(page, childContainerName)).toBeVisible();
 
         await getListItemLocator(page, childContainerName).click();
+        await expect(page).toHaveURL(new RegExp(`/container/${childContainerId}$`));
         await expect(getListItemLocator(page, leafItemName)).toBeVisible();
 
         const breadcrumbButton = page.getByRole('button', { name: `Navigate to ${rootContainerName}` });
         await expect(breadcrumbButton).toBeVisible();
         await breadcrumbButton.click();
 
+        await expect(page).toHaveURL(new RegExp(`/container/${rootContainerId}$`));
         await expect(getListItemLocator(page, childContainerName)).toBeVisible();
     });
 });
 
 test.describe('Tags view', () => {
     test('supports creating, renaming, and deleting tags', async ({ page }) => {
-        await page.getByRole('button', { name: 'Tags' }).click();
+        await page
+            .getByRole('navigation', { name: 'Desktop primary navigation' })
+            .getByRole('link', { name: 'Tags' })
+            .click();
 
         const tagName = `Tag ${Date.now()}`;
-        await page.getByRole('button', { name: /new tag/i }).first().click();
+        await page
+            .getByRole('button', { name: /new tag/i })
+            .first()
+            .click();
         await page.locator('input[name="name"]').fill(tagName);
         await page.getByRole('button', { name: /create tag/i }).click();
         await expect(page.locator('input[name="name"]')).not.toBeVisible({ timeout: 10000 });
@@ -157,7 +241,10 @@ test.describe('Tags view', () => {
 
         await reloadAndWait(page);
 
-        await page.getByRole('button', { name: 'Tags' }).click();
+        await page
+            .getByRole('navigation', { name: 'Desktop primary navigation' })
+            .getByRole('link', { name: 'Tags' })
+            .click();
         await expect(page.locator('.tag-body', { hasText: tagName }).filter({ hasText: '1 item' })).toBeVisible({
             timeout: 10000,
         });

--- a/tests/e2e/app/tag-management.spec.ts
+++ b/tests/e2e/app/tag-management.spec.ts
@@ -308,7 +308,10 @@ test.describe('T012: CreateTagDialog Integration (Ported from Storybook)', () =>
         await tagsPage.goto();
 
         // Open dialog
-        await page.getByRole('button', { name: /new tag/i }).first().click();
+        await page
+            .getByRole('button', { name: /new tag/i })
+            .first()
+            .click();
 
         // Wait for dialog
         await page.waitForSelector('input[name="name"]', { state: 'visible' });
@@ -323,7 +326,10 @@ test.describe('T012: CreateTagDialog Integration (Ported from Storybook)', () =>
         await tagsPage.goto();
 
         // Open dialog
-        await page.getByRole('button', { name: /new tag/i }).first().click();
+        await page
+            .getByRole('button', { name: /new tag/i })
+            .first()
+            .click();
 
         // Wait for dialog
         await page.waitForSelector('input[name="name"]', { state: 'visible' });
@@ -352,7 +358,10 @@ test.describe('T012: CreateTagDialog Integration (Ported from Storybook)', () =>
         await tagsPage.goto();
 
         // Open dialog
-        await page.getByRole('button', { name: /new tag/i }).first().click();
+        await page
+            .getByRole('button', { name: /new tag/i })
+            .first()
+            .click();
 
         // Wait for dialog
         await page.waitForSelector('input[name="name"]', { state: 'visible' });

--- a/tests/e2e/app/touch-optimization.spec.ts
+++ b/tests/e2e/app/touch-optimization.spec.ts
@@ -26,8 +26,9 @@ const SWIPE_BACK_END_X_PX = 150;
 
 const expectInventoryReady = async (page: Page): Promise<void> => {
     await waitForMeteorReady(page);
-    await expect(page.getByRole('heading', { name: 'Inventory App' })).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Items' })).toBeVisible();
+    await expect(page.getByText('Inventory App', { exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Inventory App' })).toHaveCount(0);
+    await expect(page.getByRole('heading', { name: 'All Items', exact: true })).toBeVisible();
 };
 
 const getItemsList = (page: Page): Locator => page.getByTestId('items-list');
@@ -249,7 +250,7 @@ test.describe('Touch Optimization - User Story 5', () => {
         // Should navigate back to root (All Items)
         // Breadcrumb should no longer show Parent Container as current
         // The parent container should now be visible as an item in the list
-        await expect(page.getByText('Parent Container', { exact: true })).toBeVisible({
+        await expect(page.getByTestId('items-list').getByText('Parent Container', { exact: true })).toBeVisible({
             timeout: 2000,
         });
     });


### PR DESCRIPTION
## Summary

- Adds route-backed item details and container URL state for direct links, back navigation, deletion return targets, invalid container routes, and scoped search context.
- Improves list and navigation accessibility by using semantic links, removing nested interactive link-button markup, and preserving keyboard navigation.
- Fixes natural sorting, breadcrumb rendering/cycle guards, duplicate home-page Items labeling, header heading hierarchy, long item-name truncation, and route-change modal cleanup.
- Expands app, audit, and unit coverage for the fixed audit issues.

## Fixed Issues

Closes #63
Closes #87
Closes #88
Closes #89
Closes #90
Closes #92
Closes #95
Closes #98
Closes #99
Closes #101
Closes #102

## Out Of Scope

- #93 remains open for a product decision about the `/settings/data` breakpoint behavior.
- #36 remains open as a separate dependency-upgrade PR.

## Validation

- `npm run format:check`
- `cd meteor-app && npm run check:type`
- `cd meteor-app && npm run check:code-style`
- `git diff --check`
- `npx playwright test tests/e2e/app/ --project=chromium --reporter=line` — 75 passed
- `npx playwright test tests/e2e/audit/ --project=chromium --reporter=line` — 24 passed
- `cd meteor-app && npm test` — 221 passing
