### PR TITLE
feat: add trustworthy item attachments

### DIFF
--- a/meteor-app/imports/api/attachmentValidation.test.ts
+++ b/meteor-app/imports/api/attachmentValidation.test.ts
@@ -1,0 +1,69 @@
+import assert from 'assert';
+
+import {
+    assertAttachmentId,
+    AttachmentRequestError,
+    buildAttachmentContentDisposition,
+    decodeAndSanitizeFilename,
+    detectAttachmentType,
+    MAX_ATTACHMENT_BYTES,
+} from './attachmentValidation';
+
+describe('attachmentValidation', function () {
+    it('uses an exact 20 MiB limit', function () {
+        assert.strictEqual(MAX_ATTACHMENT_BYTES, 20 * 1024 * 1024);
+    });
+
+    it('detects supported types from bytes', function () {
+        assert.deepStrictEqual(detectAttachmentType(Uint8Array.from([0xff, 0xd8, 0xff, 0x00])), {
+            type: 'photo',
+            mimeType: 'image/jpeg',
+        });
+        assert.deepStrictEqual(
+            detectAttachmentType(Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])),
+            { type: 'photo', mimeType: 'image/png' }
+        );
+        assert.deepStrictEqual(detectAttachmentType(new TextEncoder().encode('%PDF-1.7')), {
+            type: 'pdf',
+            mimeType: 'application/pdf',
+        });
+    });
+
+    it('rejects unsupported and truncated signatures', function () {
+        for (const bytes of [new TextEncoder().encode('plain text'), Uint8Array.from([0xff, 0xd8])]) {
+            assert.throws(
+                () => detectAttachmentType(bytes),
+                (error: unknown) =>
+                    error instanceof AttachmentRequestError && error.status === 400 && error.code === 'unsupported-file'
+            );
+        }
+    });
+
+    it('decodes, normalizes, and sanitizes filenames', function () {
+        assert.strictEqual(decodeAndSanitizeFilename(encodeURIComponent(' café receipt.pdf ')), 'café receipt.pdf');
+        assert.strictEqual(
+            decodeAndSanitizeFilename(encodeURIComponent('../folder\\receipt\r\n.pdf')),
+            '..folderreceipt.pdf'
+        );
+        assert.strictEqual(decodeAndSanitizeFilename(encodeURIComponent('/\\\r\n')), 'attachment');
+        assert.strictEqual(Array.from(decodeAndSanitizeFilename(encodeURIComponent('😀'.repeat(300)))).length, 255);
+    });
+
+    it('rejects missing and malformed filename encodings', function () {
+        assert.throws(() => decodeAndSanitizeFilename(undefined), /filename is required/u);
+        assert.throws(() => decodeAndSanitizeFilename('%E0%A4%A'), /encoding is invalid/u);
+    });
+
+    it('validates Meteor-style IDs', function () {
+        assert.strictEqual(assertAttachmentId('Abc_123-def', 'item'), 'Abc_123-def');
+        assert.throws(() => assertAttachmentId('../item', 'item'), /item ID is invalid/u);
+        assert.throws(() => assertAttachmentId('', 'attachment'), /attachment ID is invalid/u);
+    });
+
+    it('builds safe ASCII and UTF-8 download filenames', function () {
+        assert.strictEqual(
+            buildAttachmentContentDisposition('café "receipt".pdf'),
+            'attachment; filename="caf_ _receipt_.pdf"; filename*=UTF-8\'\'caf%C3%A9%20%22receipt%22.pdf'
+        );
+    });
+});

--- a/meteor-app/imports/api/attachmentValidation.ts
+++ b/meteor-app/imports/api/attachmentValidation.ts
@@ -1,0 +1,125 @@
+/**
+ * Pure validation and response-header helpers for the attachment boundary.
+ * Kept free of Meteor and storage I/O so untrusted request inputs can be tested
+ * consistently before the server allocates metadata or GridFS blobs.
+ */
+
+// File-size and protocol constants are intentionally exact external-boundary values.
+// eslint-disable-next-line @typescript-eslint/no-magic-numbers
+export const MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024;
+
+export const ATTACHMENT_HTTP_STATUS = {
+    ok: 200,
+    created: 201,
+    noContent: 204,
+    badRequest: 400,
+    notFound: 404,
+    methodNotAllowed: 405,
+    conflict: 409,
+    contentTooLarge: 413,
+    internalServerError: 500,
+} as const;
+
+const MAX_FILENAME_CODE_POINTS = 255;
+const ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+// eslint-disable-next-line @typescript-eslint/no-magic-numbers -- standardized file signatures
+const JPEG_SIGNATURE = [0xff, 0xd8, 0xff] as const;
+// eslint-disable-next-line @typescript-eslint/no-magic-numbers -- standardized file signatures
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a] as const;
+// eslint-disable-next-line @typescript-eslint/no-magic-numbers -- standardized file signatures
+const PDF_SIGNATURE = [0x25, 0x50, 0x44, 0x46, 0x2d] as const;
+const HEX_RADIX = 16;
+
+export interface ValidatedAttachmentType {
+    type: 'photo' | 'pdf';
+    mimeType: 'image/jpeg' | 'image/png' | 'application/pdf';
+}
+
+export class AttachmentRequestError extends Error {
+    constructor(readonly status: number, readonly code: string, message: string) {
+        super(message);
+        this.name = 'AttachmentRequestError';
+    }
+}
+
+const beginsWith = (bytes: Uint8Array, signature: readonly number[]): boolean => {
+    return bytes.length >= signature.length && signature.every((value, index) => bytes[index] === value);
+};
+
+export const detectAttachmentType = (bytes: Uint8Array): ValidatedAttachmentType => {
+    if (beginsWith(bytes, JPEG_SIGNATURE)) {
+        return { type: 'photo', mimeType: 'image/jpeg' };
+    }
+
+    if (beginsWith(bytes, PNG_SIGNATURE)) {
+        return { type: 'photo', mimeType: 'image/png' };
+    }
+
+    if (beginsWith(bytes, PDF_SIGNATURE)) {
+        return { type: 'pdf', mimeType: 'application/pdf' };
+    }
+
+    throw new AttachmentRequestError(
+        ATTACHMENT_HTTP_STATUS.badRequest,
+        'unsupported-file',
+        'Choose a valid JPEG, PNG, or PDF file.'
+    );
+};
+
+export const decodeAndSanitizeFilename = (encodedFilename: string | undefined): string => {
+    if (encodedFilename === undefined || encodedFilename === '') {
+        throw new AttachmentRequestError(
+            ATTACHMENT_HTTP_STATUS.badRequest,
+            'invalid-request',
+            'A filename is required.'
+        );
+    }
+
+    const decoded = (() => {
+        try {
+            return decodeURIComponent(encodedFilename);
+        } catch {
+            throw new AttachmentRequestError(
+                ATTACHMENT_HTTP_STATUS.badRequest,
+                'invalid-request',
+                'The filename encoding is invalid.'
+            );
+        }
+    })();
+
+    const sanitized = Array.from(
+        decoded
+            .normalize('NFC')
+            // eslint-disable-next-line no-control-regex -- removing HTTP header/path hazards is intentional
+            .replace(/[\u0000-\u001f\u007f/\\]/gu, '')
+            .trim()
+    )
+        .slice(0, MAX_FILENAME_CODE_POINTS)
+        .join('');
+
+    return sanitized === '' ? 'attachment' : sanitized;
+};
+
+export const assertAttachmentId = (value: string, label: 'item' | 'attachment'): string => {
+    if (!ID_PATTERN.test(value)) {
+        throw new AttachmentRequestError(
+            ATTACHMENT_HTTP_STATUS.badRequest,
+            'invalid-request',
+            `The ${label} ID is invalid.`
+        );
+    }
+
+    return value;
+};
+
+const encodeRfc5987Value = (value: string): string => {
+    return encodeURIComponent(value).replace(/[!'()*]/gu, (character) => {
+        return `%${character.charCodeAt(0).toString(HEX_RADIX).toUpperCase()}`;
+    });
+};
+
+export const buildAttachmentContentDisposition = (filename: string): string => {
+    const replacedFallback = filename.replace(/[^\x20-\x7e]|["\\]/gu, '_');
+    const asciiFallback = replacedFallback === '' ? 'attachment' : replacedFallback;
+    return `attachment; filename="${asciiFallback}"; filename*=UTF-8''${encodeRfc5987Value(filename)}`;
+};

--- a/meteor-app/imports/api/attachments.ts
+++ b/meteor-app/imports/api/attachments.ts
@@ -1,3 +1,10 @@
+/**
+ * Shared reactive metadata boundary for item attachments.
+ * Defines the client collection and ready-only publication; byte validation,
+ * HTTP transport, and GridFS lifecycle work remain server responsibilities.
+ */
+import { Meteor } from 'meteor/meteor';
+
 import type { Attachment } from '/imports/model/Attachment';
 import { NamedCollection } from '/imports/utility/NamedCollection';
 
@@ -5,7 +12,20 @@ import { NamedCollection } from '/imports/utility/NamedCollection';
  * Attachments collection for photos and PDF documents
  *
  * Stores metadata for files uploaded to GridFS
- * Supports photos (JPEG, PNG, HEIC) and PDFs (documents)
+ * The ready publication currently supports JPEG, PNG, and PDF metadata.
  * Max file size: 20MB per file
  */
 export const Attachments = new NamedCollection<Attachment>('attachments');
+
+if (Meteor.isServer) {
+    Meteor.publish('attachments.byItem', function publishAttachmentsByItem(itemId: string) {
+        if (typeof itemId !== 'string' || itemId.trim() === '') {
+            this.ready();
+            return;
+        }
+
+        return Attachments.find({ itemId, storageState: 'ready' }, { sort: { order: 1, createdAt: 1, _id: 1 } });
+    });
+}
+
+export default Attachments;

--- a/meteor-app/imports/api/items.test.ts
+++ b/meteor-app/imports/api/items.test.ts
@@ -3,10 +3,12 @@ import assert from 'assert';
 import { Meteor } from 'meteor/meteor';
 import { Random } from 'meteor/random';
 
+import type { Attachment } from '/imports/model/Attachment';
 import type InventoryItem from '/imports/model/InventoryItem';
 import RecordNotFoundException from '/imports/model/RecordNotFoundException';
 import type NoId from '/imports/utility/NoId';
 
+import { Attachments } from './attachments';
 import {
     InventoryItemsCollection,
     createInventoryItem,
@@ -477,6 +479,35 @@ describe('items', function () {
                 async () => await deleteInventoryItem(containerId),
                 /Cannot delete container with \d+ child items/
             );
+        });
+
+        it('refuses to delete an item while attachment metadata exists', async function () {
+            const itemId = await createTestItemDirect('Item with attachment', false);
+            const now = new Date();
+            const attachment: NoId<Attachment> = {
+                itemId,
+                type: 'pdf',
+                fileId: Random.id(),
+                storageState: 'ready',
+                label: 'receipt.pdf',
+                originalFilename: 'receipt.pdf',
+                mimeType: 'application/pdf',
+                fileSize: 12,
+                order: 0,
+                isPrimary: false,
+                createdAt: now,
+                modifiedAt: now,
+            };
+            const attachmentId = await Attachments.insertAsync(attachment);
+
+            try {
+                await assert.rejects(
+                    async () => await deleteInventoryItem(itemId),
+                    /Cannot delete item with 1 attachment\. Delete attachments first\./
+                );
+            } finally {
+                await Attachments.removeAsync({ _id: attachmentId });
+            }
         });
 
         it('throws RecordNotFoundException when item does not exist', async function () {

--- a/meteor-app/imports/api/items.ts
+++ b/meteor-app/imports/api/items.ts
@@ -1,6 +1,12 @@
+/**
+ * Inventory item persistence, domain validation, methods, and publications.
+ * Owns item hierarchy invariants; attachment bytes remain separate, while item
+ * deletion refuses to orphan attachment metadata or GridFS blobs.
+ */
 import { Meteor } from 'meteor/meteor';
 import type { Mongo } from 'meteor/mongo';
 
+import { Attachments } from '/imports/api/attachments';
 import type InventoryItem from '/imports/model/InventoryItem';
 import { MAX_ITEM_DESCRIPTION_LENGTH, MAX_ITEM_NAME_LENGTH } from '/imports/model/ItemConstants';
 import RecordNotFoundException from '/imports/model/RecordNotFoundException';
@@ -294,6 +300,15 @@ export const deleteInventoryItem = async (itemId: string): Promise<number> => {
         if (childCount > 0) {
             throw new Error(`Cannot delete container with ${childCount} child items. Move or delete children first.`);
         }
+    }
+
+    const attachmentCount = await Attachments.find({ itemId }).countAsync();
+    if (attachmentCount > 0) {
+        throw new Error(
+            `Cannot delete item with ${attachmentCount} ${
+                attachmentCount === 1 ? 'attachment' : 'attachments'
+            }. Delete attachments first.`
+        );
     }
 
     const result = await InventoryItemsCollection.removeAsync({ _id: itemId });

--- a/meteor-app/imports/model/Attachment.ts
+++ b/meteor-app/imports/model/Attachment.ts
@@ -1,11 +1,16 @@
+/**
+ * Persistent metadata for item-owned attachment blobs.
+ * The storage state coordinates recoverable GridFS writes and deletes; raw
+ * bytes and transport behavior belong to server attachment modules.
+ */
 import type { CollectionItem } from '/imports/model/CollectionItem';
 
 /**
  * Attachment model for photos and PDF documents attached to items
  *
- * Supports:
- * - Photos: JPEG, PNG, HEIC with thumbnail generation and EXIF correction
- * - PDFs: Documents like receipts, warranties, manuals
+ * The first shipping slice supports JPEG/PNG photos with generated thumbnails
+ * and PDF documents. Additional formats and richer ordering/primary controls
+ * remain represented for planned follow-up work.
  *
  * File storage: GridFS
  * Max file size: 20MB per file
@@ -22,6 +27,9 @@ export interface Attachment extends CollectionItem {
 
     /** GridFS file ID for thumbnail (photos only) */
     thumbnailId?: string;
+
+    /** Recoverable state spanning MongoDB metadata and GridFS blob operations */
+    storageState: 'uploading' | 'ready' | 'deleting';
 
     /** User-customizable label, defaults to original filename */
     label: string;

--- a/meteor-app/imports/ui/AppShell.tsx
+++ b/meteor-app/imports/ui/AppShell.tsx
@@ -94,6 +94,7 @@ export const AppShell = ({ children, location }: AppShellProps): ReactElement =>
 
             <Nav
                 direction="row"
+                gap="none"
                 aria-label="Mobile primary navigation"
                 className="app-shell-mobile-nav"
                 data-testid="mobile-primary-navigation"

--- a/meteor-app/imports/ui/AttachmentPanel.stories.tsx
+++ b/meteor-app/imports/ui/AttachmentPanel.stories.tsx
@@ -1,0 +1,163 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Box, Text } from 'grommet';
+import React, { useState } from 'react';
+
+import type { Attachment } from '/imports/model/Attachment';
+import { AttachmentPanel, type AttachmentPanelProps } from '/imports/ui/AttachmentPanel';
+
+const ITEM_ID = 'storybook-item';
+const NOW = new Date('2026-07-15T00:00:00Z');
+
+const photoAttachment: Attachment = {
+    _id: 'photo-attachment',
+    itemId: ITEM_ID,
+    type: 'photo',
+    fileId: '507f1f77bcf86cd799439011',
+    thumbnailId: '507f1f77bcf86cd799439012',
+    storageState: 'ready',
+    label: 'garage shelf.png',
+    originalFilename: 'garage shelf.png',
+    mimeType: 'image/png',
+    fileSize: 48_200,
+    order: 0,
+    isPrimary: true,
+    width: 1200,
+    height: 900,
+    createdAt: NOW,
+    modifiedAt: NOW,
+};
+
+const pdfAttachment: Attachment = {
+    _id: 'pdf-attachment',
+    itemId: ITEM_ID,
+    type: 'pdf',
+    fileId: '507f1f77bcf86cd799439013',
+    storageState: 'ready',
+    label: 'purchase receipt.pdf',
+    originalFilename: 'purchase receipt.pdf',
+    mimeType: 'application/pdf',
+    fileSize: 1_480_000,
+    order: 1,
+    isPrimary: false,
+    createdAt: NOW,
+    modifiedAt: NOW,
+};
+
+const idleCallbacks: Pick<AttachmentPanelProps, 'onUpload' | 'onDelete'> = {
+    onUpload: async () => {
+        await Promise.resolve();
+    },
+    onDelete: async () => {
+        await Promise.resolve();
+    },
+};
+
+const meta = {
+    title: 'UI/AttachmentPanel',
+    component: AttachmentPanel,
+    parameters: { layout: 'padded' },
+    tags: ['autodocs'],
+    decorators: [
+        (Story) => (
+            <Box width={{ max: 'large' }} margin="auto">
+                <Story />
+            </Box>
+        ),
+    ],
+    args: {
+        itemId: ITEM_ID,
+        attachments: [],
+        ...idleCallbacks,
+    },
+} satisfies Meta<typeof AttachmentPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {};
+
+export const WithAttachments: Story = {
+    args: { attachments: [photoAttachment, pdfAttachment] },
+};
+
+export const Loading: Story = {
+    args: { isLoading: true },
+};
+
+export const Uploading: Story = {
+    args: { attachments: [photoAttachment], isUploading: true },
+};
+
+export const ErrorState: Story = {
+    args: {
+        attachments: [pdfAttachment],
+        errorMessage: 'The attachment could not be stored. Try again.',
+    },
+};
+
+export const MissingThumbnail: Story = {
+    args: { attachments: [photoAttachment] },
+};
+
+export const Deleting: Story = {
+    args: {
+        attachments: [photoAttachment, pdfAttachment],
+        deletingAttachmentId: photoAttachment._id,
+    },
+};
+
+export const Interactive: Story = {
+    render: (args) => {
+        const [attachments, setAttachments] = useState<Attachment[]>(args.attachments);
+        const [isUploading, setIsUploading] = useState(false);
+        const [deletingAttachmentId, setDeletingAttachmentId] = useState<string | undefined>();
+        const [lastAction, setLastAction] = useState('No action yet');
+
+        return (
+            <Box gap="small">
+                <AttachmentPanel
+                    {...args}
+                    attachments={attachments}
+                    isUploading={isUploading}
+                    deletingAttachmentId={deletingAttachmentId}
+                    onUpload={async (file) => {
+                        setIsUploading(true);
+                        await new Promise((resolve) => setTimeout(resolve, 250));
+                        const timestamp = new Date();
+                        setAttachments((current) => [
+                            ...current,
+                            {
+                                _id: `uploaded-${current.length}`,
+                                itemId: ITEM_ID,
+                                type: file.type === 'application/pdf' ? 'pdf' : 'photo',
+                                fileId: `file-${current.length}`,
+                                thumbnailId: file.type === 'application/pdf' ? undefined : `thumb-${current.length}`,
+                                storageState: 'ready',
+                                label: file.name,
+                                originalFilename: file.name,
+                                mimeType: file.type,
+                                fileSize: file.size,
+                                order: current.length,
+                                isPrimary: current.every((attachment) => attachment.type !== 'photo'),
+                                createdAt: timestamp,
+                                modifiedAt: timestamp,
+                            },
+                        ]);
+                        setLastAction(`Uploaded ${file.name}`);
+                        setIsUploading(false);
+                    }}
+                    onDelete={async (attachment) => {
+                        setDeletingAttachmentId(attachment._id);
+                        await new Promise((resolve) => setTimeout(resolve, 250));
+                        setAttachments((current) => current.filter((candidate) => candidate._id !== attachment._id));
+                        setLastAction(`Deleted ${attachment.label}`);
+                        setDeletingAttachmentId(undefined);
+                    }}
+                />
+                <Text data-testid="attachment-story-action">{lastAction}</Text>
+                <Text data-testid="attachment-story-count">{attachments.length}</Text>
+            </Box>
+        );
+    },
+    args: { attachments: [pdfAttachment] },
+};

--- a/meteor-app/imports/ui/AttachmentPanel.tsx
+++ b/meteor-app/imports/ui/AttachmentPanel.tsx
@@ -1,0 +1,310 @@
+/**
+ * Touch-ready presentation and local interaction state for item attachments.
+ * Owns file selection and delete confirmation while callers provide reactive
+ * metadata plus the actual upload and deletion operations.
+ */
+import { Box, Button, Heading, Text } from 'grommet';
+import { Attachment as AttachmentIcon, Document, Download, Trash, Upload } from 'grommet-icons';
+import React, { useRef, useState } from 'react';
+import styled from 'styled-components';
+
+import { MAX_ATTACHMENT_BYTES } from '/imports/api/attachmentValidation';
+import type { Attachment } from '/imports/model/Attachment';
+import { LoadingSpinner } from '/imports/ui/LoadingSpinner';
+import { uiTokens } from '/imports/ui/theme';
+
+const ACCEPTED_FILE_TYPES = 'image/jpeg,image/png,application/pdf';
+const ACCEPTED_MIME_TYPES = new Set(ACCEPTED_FILE_TYPES.split(','));
+const BYTES_PER_KIBIBYTE = 1024;
+const BYTES_PER_MEBIBYTE = BYTES_PER_KIBIBYTE * BYTES_PER_KIBIBYTE;
+
+const Panel = styled(Box)`
+    border: 1px solid ${uiTokens.color.border};
+    border-radius: ${uiTokens.radius.control};
+    background: ${uiTokens.color.surfaceRaised};
+`;
+
+const FileInput = styled.input`
+    min-height: ${uiTokens.size.touchTarget};
+    width: 100%;
+    color: ${uiTokens.color.text};
+
+    &::file-selector-button {
+        min-height: ${uiTokens.size.touchTarget};
+        margin-right: ${uiTokens.space.md};
+        padding: 0 ${uiTokens.space.lg};
+        border: 1px solid ${uiTokens.color.borderStrong};
+        border-radius: ${uiTokens.radius.control};
+        background: ${uiTokens.color.surfaceSubtle};
+        color: ${uiTokens.color.text};
+        cursor: pointer;
+    }
+
+    &:disabled::file-selector-button {
+        cursor: not-allowed;
+        opacity: 0.6;
+    }
+`;
+
+const AttachmentRow = styled(Box)`
+    border: 1px solid ${uiTokens.color.borderSubtle};
+    border-radius: ${uiTokens.radius.control};
+    background: ${uiTokens.color.surfaceSunken};
+`;
+
+const PreviewImage = styled.img`
+    width: 72px;
+    height: 72px;
+    flex: 0 0 72px;
+    border-radius: ${uiTokens.radius.small};
+    object-fit: cover;
+    background: ${uiTokens.color.surfaceSubtle};
+`;
+
+const PreviewFallback = styled(Box)`
+    width: 72px;
+    height: 72px;
+    flex: 0 0 72px;
+    border-radius: ${uiTokens.radius.small};
+    background: ${uiTokens.color.surfaceSubtle};
+`;
+
+const ActionLink = styled.a`
+    display: inline-flex;
+    min-height: ${uiTokens.size.touchTarget};
+    align-items: center;
+    gap: ${uiTokens.space.sm};
+    padding: 0 ${uiTokens.space.md};
+    border-radius: ${uiTokens.radius.control};
+    color: ${uiTokens.color.brand};
+    font-weight: ${uiTokens.font.weightMedium};
+    text-decoration: none;
+
+    &:hover {
+        background: ${uiTokens.color.brandGhostHover};
+    }
+`;
+
+export interface AttachmentPanelProps {
+    itemId: string;
+    attachments: Attachment[];
+    isLoading?: boolean;
+    isUploading?: boolean;
+    deletingAttachmentId?: string;
+    errorMessage?: string;
+    onUpload: (file: File) => Promise<void>;
+    onDelete: (attachment: Attachment) => Promise<void>;
+}
+
+const getAttachmentUrl = (itemId: string, attachmentId: string, target: 'content' | 'thumbnail'): string => {
+    return `/api/items/${encodeURIComponent(itemId)}/attachments/${encodeURIComponent(attachmentId)}/${target}`;
+};
+
+const formatFileSize = (bytes: number): string => {
+    if (bytes >= BYTES_PER_MEBIBYTE) return `${(bytes / BYTES_PER_MEBIBYTE).toFixed(1)} MiB`;
+    return `${Math.max(1, Math.round(bytes / BYTES_PER_KIBIBYTE))} KiB`;
+};
+
+const getSelectionError = (file: File): string | undefined => {
+    if (file.size > MAX_ATTACHMENT_BYTES) return 'Choose a file that is 20 MiB or smaller.';
+    if (file.type !== '' && !ACCEPTED_MIME_TYPES.has(file.type)) return 'Choose a JPEG, PNG, or PDF file.';
+    return undefined;
+};
+
+export const AttachmentPanel: React.FC<AttachmentPanelProps> = ({
+    itemId,
+    attachments,
+    isLoading = false,
+    isUploading = false,
+    deletingAttachmentId,
+    errorMessage,
+    onUpload,
+    onDelete,
+}) => {
+    const inputRef = useRef<HTMLInputElement>(null);
+    const [selectedFile, setSelectedFile] = useState<File | undefined>();
+    const [selectionError, setSelectionError] = useState<string | undefined>();
+    const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | undefined>();
+    const [failedPreviews, setFailedPreviews] = useState<Set<string>>(() => new Set());
+
+    const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+        const file = event.target.files?.[0];
+        setSelectedFile(file);
+        setSelectionError(file === undefined ? undefined : getSelectionError(file));
+    };
+
+    const handleUpload = async (): Promise<void> => {
+        if (selectedFile === undefined || selectionError !== undefined || isUploading) return;
+
+        try {
+            await onUpload(selectedFile);
+            setSelectedFile(undefined);
+            if (inputRef.current !== null) inputRef.current.value = '';
+        } catch {
+            // The caller exposes the server error through errorMessage.
+        }
+    };
+
+    const handleDelete = async (attachment: Attachment): Promise<void> => {
+        try {
+            await onDelete(attachment);
+            setConfirmingDeleteId(undefined);
+        } catch {
+            // The caller exposes the server error through errorMessage.
+        }
+    };
+
+    return (
+        <Panel pad="medium" gap="medium" data-testid="attachment-panel">
+            <Box gap="xsmall">
+                <Heading level={3} margin="none">
+                    Attachments
+                </Heading>
+                <Text size="small" color="text-weak">
+                    Add one JPEG, PNG, or PDF at a time, up to 20 MiB.
+                </Text>
+            </Box>
+
+            <Box gap="small">
+                <label htmlFor="attachment-file">
+                    <Text weight="bold">Choose a file</Text>
+                </label>
+                <FileInput
+                    ref={inputRef}
+                    id="attachment-file"
+                    data-testid="attachment-file-input"
+                    type="file"
+                    accept={ACCEPTED_FILE_TYPES}
+                    disabled={isUploading}
+                    onChange={handleFileChange}
+                />
+                {selectedFile !== undefined && selectionError === undefined && (
+                    <Text size="small" color="text-weak">
+                        Selected: {selectedFile.name} ({formatFileSize(selectedFile.size)})
+                    </Text>
+                )}
+                {selectionError !== undefined && (
+                    <Text role="alert" color="status-critical" data-testid="attachment-selection-error">
+                        {selectionError}
+                    </Text>
+                )}
+                <Box direction="row" align="center" gap="small">
+                    <Button
+                        primary
+                        icon={<Upload />}
+                        label={isUploading ? 'Uploading…' : 'Upload attachment'}
+                        disabled={selectedFile === undefined || selectionError !== undefined || isUploading}
+                        onClick={() => {
+                            void handleUpload();
+                        }}
+                    />
+                    {isUploading && <LoadingSpinner size="small" ariaLabel="Uploading attachment" />}
+                </Box>
+            </Box>
+
+            {errorMessage !== undefined && (
+                <Text role="alert" color="status-critical" data-testid="attachment-error">
+                    {errorMessage}
+                </Text>
+            )}
+
+            {isLoading ? (
+                <Box align="center" pad="medium">
+                    <LoadingSpinner size="small" text="Loading attachments…" ariaLabel="Loading attachments" />
+                </Box>
+            ) : attachments.length === 0 ? (
+                <Box align="center" pad="medium" gap="small">
+                    <AttachmentIcon color="text-weak" aria-hidden="true" />
+                    <Text color="text-weak">No attachments yet.</Text>
+                </Box>
+            ) : (
+                <Box gap="small" aria-label="Item attachments">
+                    {attachments.map((attachment) => {
+                        const isDeleting = deletingAttachmentId === attachment._id;
+                        const isConfirmingDelete = confirmingDeleteId === attachment._id;
+                        const previewFailed = failedPreviews.has(attachment._id);
+
+                        return (
+                            <AttachmentRow key={attachment._id} pad="small" gap="small" data-testid="attachment-row">
+                                <Box direction="row" align="center" gap="medium">
+                                    {attachment.type === 'photo' && !previewFailed ? (
+                                        <PreviewImage
+                                            src={getAttachmentUrl(itemId, attachment._id, 'thumbnail')}
+                                            alt={`Preview of ${attachment.label}`}
+                                            onError={() => {
+                                                setFailedPreviews((current) => new Set(current).add(attachment._id));
+                                            }}
+                                        />
+                                    ) : (
+                                        <PreviewFallback align="center" justify="center" gap="xsmall">
+                                            <Document aria-hidden="true" />
+                                            {attachment.type === 'photo' && (
+                                                <Text size="xsmall" textAlign="center">
+                                                    Preview unavailable
+                                                </Text>
+                                            )}
+                                        </PreviewFallback>
+                                    )}
+
+                                    <Box flex="grow" gap="xxsmall">
+                                        <Text weight="bold">{attachment.label}</Text>
+                                        <Text size="small" color="text-weak">
+                                            {attachment.type === 'photo' ? 'Image' : 'PDF'} ·{' '}
+                                            {formatFileSize(attachment.fileSize)}
+                                        </Text>
+                                    </Box>
+                                </Box>
+
+                                {isConfirmingDelete ? (
+                                    <Box gap="small" background="status-critical" pad="small" round="small">
+                                        <Text color="white">
+                                            Delete “{attachment.label}”? This removes the stored file and cannot be
+                                            undone.
+                                        </Text>
+                                        <Box direction="row" justify="end" gap="small" wrap>
+                                            <Button
+                                                label="Cancel"
+                                                disabled={isDeleting}
+                                                onClick={() => {
+                                                    setConfirmingDeleteId(undefined);
+                                                }}
+                                            />
+                                            <Button
+                                                label={isDeleting ? 'Deleting…' : 'Delete attachment'}
+                                                icon={<Trash />}
+                                                color="white"
+                                                disabled={isDeleting}
+                                                onClick={() => {
+                                                    void handleDelete(attachment);
+                                                }}
+                                            />
+                                        </Box>
+                                    </Box>
+                                ) : (
+                                    <Box direction="row" gap="small" wrap>
+                                        <ActionLink
+                                            href={getAttachmentUrl(itemId, attachment._id, 'content')}
+                                            download={attachment.originalFilename}
+                                        >
+                                            <Download aria-hidden="true" />
+                                            Download
+                                        </ActionLink>
+                                        <Button
+                                            icon={<Trash />}
+                                            label="Delete"
+                                            color="status-critical"
+                                            disabled={deletingAttachmentId !== undefined}
+                                            onClick={() => {
+                                                setConfirmingDeleteId(attachment._id);
+                                            }}
+                                        />
+                                    </Box>
+                                )}
+                            </AttachmentRow>
+                        );
+                    })}
+                </Box>
+            )}
+        </Panel>
+    );
+};

--- a/meteor-app/imports/ui/ItemDetailView.tsx
+++ b/meteor-app/imports/ui/ItemDetailView.tsx
@@ -7,9 +7,12 @@ import { Close } from 'grommet-icons';
 import React, { useState } from 'react';
 import { useParams, Link, useLocation } from 'wouter';
 
+import { Attachments } from '/imports/api/attachments';
 import Items, { InventoryItemsCollection } from '/imports/api/items';
 import Tags, { TagsCollection } from '/imports/api/tags';
+import type { Attachment } from '/imports/model/Attachment';
 import type { InventoryItem } from '/imports/model/InventoryItem';
+import { AttachmentPanel } from '/imports/ui/AttachmentPanel';
 import { LoadingState } from '/imports/ui/common/LoadingState';
 import { ContainerSelector } from '/imports/ui/ContainerSelector';
 import { ItemDetailViewPresentation } from '/imports/ui/ItemDetailViewPresentation';
@@ -24,6 +27,16 @@ export { ItemDetailViewPresentation } from '/imports/ui/ItemDetailViewPresentati
 
 const getErrorMessage = (error: unknown): string => {
     return error instanceof Error ? error.message : 'Something went wrong. Please try again.';
+};
+
+const getAttachmentResponseError = async (response: Response): Promise<Error> => {
+    try {
+        const body = (await response.json()) as { message?: unknown };
+        if (typeof body.message === 'string' && body.message !== '') return new Error(body.message);
+    } catch {
+        // Fall through to a stable status-based message.
+    }
+    return new Error(`Attachment request failed (${response.status}).`);
 };
 
 const getNonEmptyContainerMessage = (childCount: number): string => {
@@ -70,10 +83,14 @@ export const ItemDetailView: React.FC<RouteItemDetailViewProps> = ({ deleteRetur
     const [moveTargetId, setMoveTargetId] = useState<string | undefined>();
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [errorMessage, setErrorMessage] = useState<string | undefined>();
+    const [isUploadingAttachment, setIsUploadingAttachment] = useState(false);
+    const [deletingAttachmentId, setDeletingAttachmentId] = useState<string | undefined>();
+    const [attachmentErrorMessage, setAttachmentErrorMessage] = useState<string | undefined>();
 
     const isLoadingItem = useSubscribe('items.byId', itemId);
     const isLoadingAllItems = useSubscribe('items.all');
     const isLoadingTags = useSubscribe('tags.all');
+    const isLoadingAttachments = useSubscribe('attachments.byItem', itemId);
 
     usePageTitle('Item Details - My Inventory');
 
@@ -104,6 +121,14 @@ export const ItemDetailView: React.FC<RouteItemDetailViewProps> = ({ deleteRetur
     const childCount = useTracker(() => {
         if (itemId === '') return 0;
         return InventoryItemsCollection.find({ containerId: itemId }).count();
+    }, [itemId]);
+
+    const attachments = useTracker(() => {
+        if (itemId === '') return [];
+        return Attachments.find(
+            { itemId, storageState: 'ready' },
+            { sort: { order: 1, createdAt: 1, _id: 1 } }
+        ).fetch();
     }, [itemId]);
 
     const containerPath = useTracker(() => {
@@ -221,6 +246,52 @@ export const ItemDetailView: React.FC<RouteItemDetailViewProps> = ({ deleteRetur
         }
     };
 
+    const handleUploadAttachment = async (file: File): Promise<void> => {
+        try {
+            setIsUploadingAttachment(true);
+            setAttachmentErrorMessage(undefined);
+            const response = await fetch(`/api/items/${encodeURIComponent(item._id)}/attachments`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': file.type === '' ? 'application/octet-stream' : file.type,
+                    'X-Inventory-Attachment-Request': '1',
+                    'X-Inventory-Filename': encodeURIComponent(file.name),
+                },
+                body: file,
+            });
+
+            if (!response.ok) throw await getAttachmentResponseError(response);
+        } catch (error) {
+            const message = getErrorMessage(error);
+            setAttachmentErrorMessage(message);
+            throw error;
+        } finally {
+            setIsUploadingAttachment(false);
+        }
+    };
+
+    const handleDeleteAttachment = async (attachment: Attachment): Promise<void> => {
+        try {
+            setDeletingAttachmentId(attachment._id);
+            setAttachmentErrorMessage(undefined);
+            const response = await fetch(
+                `/api/items/${encodeURIComponent(item._id)}/attachments/${encodeURIComponent(attachment._id)}`,
+                {
+                    method: 'DELETE',
+                    headers: { 'X-Inventory-Attachment-Request': '1' },
+                }
+            );
+
+            if (!response.ok) throw await getAttachmentResponseError(response);
+        } catch (error) {
+            const message = getErrorMessage(error);
+            setAttachmentErrorMessage(message);
+            throw error;
+        } finally {
+            setDeletingAttachmentId(undefined);
+        }
+    };
+
     // Render the presentation component with fetched data
     return (
         <>
@@ -251,6 +322,19 @@ export const ItemDetailView: React.FC<RouteItemDetailViewProps> = ({ deleteRetur
                 }}
                 disabled={isSubmitting}
             />
+
+            <Box pad={{ horizontal: 'medium', bottom: 'medium' }}>
+                <AttachmentPanel
+                    itemId={item._id}
+                    attachments={attachments}
+                    isLoading={isLoadingAttachments()}
+                    isUploading={isUploadingAttachment}
+                    deletingAttachmentId={deletingAttachmentId}
+                    errorMessage={attachmentErrorMessage}
+                    onUpload={handleUploadAttachment}
+                    onDelete={handleDeleteAttachment}
+                />
+            </Box>
 
             {isConfirmingDelete && (
                 <Layer

--- a/meteor-app/imports/ui/ItemDetailView.tsx
+++ b/meteor-app/imports/ui/ItemDetailView.tsx
@@ -294,7 +294,7 @@ export const ItemDetailView: React.FC<RouteItemDetailViewProps> = ({ deleteRetur
 
     // Render the presentation component with fetched data
     return (
-        <>
+        <Box fill overflow="auto">
             <ItemDetailViewPresentation
                 item={item}
                 tags={tags}
@@ -323,7 +323,7 @@ export const ItemDetailView: React.FC<RouteItemDetailViewProps> = ({ deleteRetur
                 disabled={isSubmitting}
             />
 
-            <Box pad={{ horizontal: 'medium', bottom: 'medium' }}>
+            <Box flex={{ shrink: 0 }} pad={{ horizontal: 'medium', bottom: 'medium' }}>
                 <AttachmentPanel
                     itemId={item._id}
                     attachments={attachments}
@@ -469,6 +469,6 @@ export const ItemDetailView: React.FC<RouteItemDetailViewProps> = ({ deleteRetur
                     </Box>
                 </Layer>
             )}
-        </>
+        </Box>
     );
 };

--- a/meteor-app/imports/ui/ItemDetailViewPresentation.tsx
+++ b/meteor-app/imports/ui/ItemDetailViewPresentation.tsx
@@ -84,7 +84,7 @@ export const ItemDetailViewPresentation: React.FC<ItemDetailViewProps> = ({
     disabled = false,
 }) => {
     return (
-        <Box fill pad="medium" gap="medium">
+        <Box fill="horizontal" flex={{ shrink: 0 }} pad="medium" gap="medium">
             {/* Header with item name and type indicator */}
             <Box direction="row" align="center" justify="between" gap="small">
                 <Heading level={2} margin="none">

--- a/meteor-app/imports/ui/SettingsDataViewPresentation.tsx
+++ b/meteor-app/imports/ui/SettingsDataViewPresentation.tsx
@@ -142,9 +142,19 @@ export const SettingsDataViewPresentation = ({
                     </Heading>
                 </CardHeader>
                 <CardBody pad="medium" gap="medium">
-                    <Text>
-                        Download a full backup of your inventory, including items, tags, and container hierarchy.
-                    </Text>
+                    <Text>Download inventory items, tags, and container hierarchy as JSON or CSV.</Text>
+                    <Box
+                        role="note"
+                        aria-label="Attachment export limitation"
+                        background="status-warning"
+                        pad="small"
+                        round="small"
+                    >
+                        <Text color="white" size="small">
+                            JSON and CSV exports do not include attachment files. Importing these files restores item
+                            and tag data, but not attachments.
+                        </Text>
+                    </Box>
                     {exportError != null && (
                         <Text color="status-critical" size="small">
                             {exportError}

--- a/meteor-app/server/attachmentRoutes.ts
+++ b/meteor-app/server/attachmentRoutes.ts
@@ -1,0 +1,323 @@
+/**
+ * HTTP transport for item attachment bytes and lifecycle operations.
+ * Parses a narrow same-origin API surface and delegates all metadata/GridFS
+ * transitions to the attachment service rather than owning storage logic.
+ */
+import type { IncomingMessage, ServerResponse } from 'http';
+
+import { WebApp } from 'meteor/webapp';
+
+import {
+    assertAttachmentId,
+    ATTACHMENT_HTTP_STATUS,
+    AttachmentRequestError,
+    buildAttachmentContentDisposition,
+    MAX_ATTACHMENT_BYTES,
+} from '/imports/api/attachmentValidation';
+import createLogger from '/imports/utility/Logger';
+
+import {
+    assertAttachmentBlobExists,
+    createAttachment,
+    deleteAttachment,
+    getReadyAttachment,
+} from './attachmentService';
+import { downloadFromGridFS } from './gridfs';
+
+const logger = createLogger(module);
+const REQUEST_MARKER_HEADER = 'x-inventory-attachment-request';
+const FILENAME_HEADER = 'x-inventory-filename';
+const COLLECTION_ROUTE_SEGMENT_COUNT = 2;
+const MEMBER_ROUTE_SEGMENT_COUNT = 3;
+const CONTENT_ROUTE_SEGMENT_COUNT = 4;
+
+type NextFunction = () => void;
+type AttachmentHttpHandler = (
+    request: IncomingMessage,
+    response: ServerResponse,
+    next: NextFunction
+) => void | Promise<void>;
+type WebAppWithHandlers = typeof WebApp & {
+    handlers: {
+        use: (path: string, handler: AttachmentHttpHandler) => void;
+    };
+};
+
+const webAppWithHandlers = WebApp as WebAppWithHandlers;
+
+const getSingleHeader = (request: IncomingMessage, name: string): string | undefined => {
+    const value = request.headers[name];
+    return typeof value === 'string' ? value : undefined;
+};
+
+const assertStateChangingRequest = (request: IncomingMessage): void => {
+    if (getSingleHeader(request, REQUEST_MARKER_HEADER) !== '1') {
+        throw new AttachmentRequestError(
+            ATTACHMENT_HTTP_STATUS.badRequest,
+            'invalid-request',
+            'The attachment request marker is missing.'
+        );
+    }
+
+    const fetchSite = getSingleHeader(request, 'sec-fetch-site');
+    if (fetchSite !== undefined && fetchSite !== 'same-origin') {
+        throw new AttachmentRequestError(
+            ATTACHMENT_HTTP_STATUS.badRequest,
+            'invalid-request',
+            'Cross-origin attachment requests are not allowed.'
+        );
+    }
+
+    const origin = getSingleHeader(request, 'origin');
+    const host = getSingleHeader(request, 'x-forwarded-host') ?? getSingleHeader(request, 'host');
+    if (origin !== undefined && host !== undefined) {
+        const originHost = (() => {
+            try {
+                return new URL(origin).host;
+            } catch {
+                throw new AttachmentRequestError(
+                    ATTACHMENT_HTTP_STATUS.badRequest,
+                    'invalid-request',
+                    'The request origin is invalid.'
+                );
+            }
+        })();
+
+        if (originHost !== host) {
+            throw new AttachmentRequestError(
+                ATTACHMENT_HTTP_STATUS.badRequest,
+                'invalid-request',
+                'Cross-origin attachment requests are not allowed.'
+            );
+        }
+    }
+};
+
+const assertContentLength = (request: IncomingMessage): void => {
+    const value = getSingleHeader(request, 'content-length');
+    if (value === undefined) return;
+
+    const length = Number(value);
+    if (!Number.isSafeInteger(length) || length < 0) {
+        throw new AttachmentRequestError(
+            ATTACHMENT_HTTP_STATUS.badRequest,
+            'invalid-request',
+            'The request length is invalid.'
+        );
+    }
+
+    if (length > MAX_ATTACHMENT_BYTES) {
+        throw new AttachmentRequestError(
+            ATTACHMENT_HTTP_STATUS.contentTooLarge,
+            'file-too-large',
+            'Attachments must be 20 MiB or smaller.'
+        );
+    }
+};
+
+const readAttachmentBody = async (request: IncomingMessage): Promise<Buffer> => {
+    assertContentLength(request);
+
+    return await new Promise<Buffer>((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        let length = 0;
+        let settled = false;
+
+        const fail = (error: Error): void => {
+            if (settled) return;
+            settled = true;
+            reject(error);
+        };
+
+        request.on('data', (chunk: Buffer | string) => {
+            if (settled) return;
+            const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+            length += buffer.length;
+
+            if (length > MAX_ATTACHMENT_BYTES) {
+                request.resume();
+                fail(
+                    new AttachmentRequestError(
+                        ATTACHMENT_HTTP_STATUS.contentTooLarge,
+                        'file-too-large',
+                        'Attachments must be 20 MiB or smaller.'
+                    )
+                );
+                return;
+            }
+
+            chunks.push(buffer);
+        });
+        request.once('aborted', () => {
+            fail(
+                new AttachmentRequestError(
+                    ATTACHMENT_HTTP_STATUS.badRequest,
+                    'invalid-request',
+                    'The attachment upload was interrupted.'
+                )
+            );
+        });
+        request.once('error', (error) => {
+            fail(error);
+        });
+        request.once('end', () => {
+            if (settled) return;
+            settled = true;
+            resolve(Buffer.concat(chunks, length));
+        });
+    });
+};
+
+const sendJson = (response: ServerResponse, status: number, body: unknown): void => {
+    response.writeHead(status, {
+        'Content-Type': 'application/json; charset=utf-8',
+        'Cache-Control': 'private, no-store',
+        'X-Content-Type-Options': 'nosniff',
+    });
+    response.end(JSON.stringify(body));
+};
+
+const sendError = (response: ServerResponse, error: unknown): void => {
+    if (error instanceof AttachmentRequestError) {
+        sendJson(response, error.status, { error: error.code, message: error.message });
+        return;
+    }
+
+    logger.warn('Unexpected attachment route error', error);
+    sendJson(response, ATTACHMENT_HTTP_STATUS.internalServerError, {
+        error: 'storage-error',
+        message: 'The attachment operation failed.',
+    });
+};
+
+const decodeId = (encodedValue: string, label: 'item' | 'attachment'): string => {
+    try {
+        return assertAttachmentId(decodeURIComponent(encodedValue), label);
+    } catch (error) {
+        if (error instanceof URIError) {
+            throw new AttachmentRequestError(
+                ATTACHMENT_HTTP_STATUS.badRequest,
+                'invalid-request',
+                `The ${label} ID encoding is invalid.`
+            );
+        }
+        throw error;
+    }
+};
+
+const streamAttachment = async (
+    response: ServerResponse,
+    fileId: string,
+    mimeType: string,
+    contentDisposition: string
+): Promise<void> => {
+    const contentLength = await assertAttachmentBlobExists(fileId);
+    const stream = downloadFromGridFS(fileId);
+
+    response.writeHead(ATTACHMENT_HTTP_STATUS.ok, {
+        'Content-Type': mimeType,
+        'Content-Length': contentLength,
+        'Content-Disposition': contentDisposition,
+        'Cache-Control': 'private, no-store',
+        'X-Content-Type-Options': 'nosniff',
+    });
+    stream.once('error', (error) => {
+        logger.warn('Attachment download stream failed', error);
+        response.destroy();
+    });
+    stream.pipe(response);
+};
+
+const handleAttachmentRequest: AttachmentHttpHandler = async (request, response, next) => {
+    const requestUrl = new URL(request.url ?? '/', 'http://inventory.local');
+    const segments = requestUrl.pathname.split('/').filter((segment) => segment !== '');
+    const [encodedItemId, collectionSegment, encodedAttachmentId, contentSegment] = segments;
+
+    const isCollectionRoute = segments.length === COLLECTION_ROUTE_SEGMENT_COUNT && collectionSegment === 'attachments';
+    const isMemberRoute = segments.length === MEMBER_ROUTE_SEGMENT_COUNT && collectionSegment === 'attachments';
+    const isContentRoute =
+        segments.length === CONTENT_ROUTE_SEGMENT_COUNT &&
+        collectionSegment === 'attachments' &&
+        (contentSegment === 'content' || contentSegment === 'thumbnail');
+
+    if (!isCollectionRoute && !isMemberRoute && !isContentRoute) {
+        next();
+        return;
+    }
+
+    try {
+        const itemId = decodeId(encodedItemId, 'item');
+
+        if (isCollectionRoute) {
+            if (request.method !== 'POST') {
+                sendJson(response, ATTACHMENT_HTTP_STATUS.methodNotAllowed, {
+                    error: 'method-not-allowed',
+                    message: 'Use POST to upload an attachment.',
+                });
+                return;
+            }
+
+            assertStateChangingRequest(request);
+            const bytes = await readAttachmentBody(request);
+            const attachment = await createAttachment(itemId, getSingleHeader(request, FILENAME_HEADER), bytes);
+            sendJson(response, ATTACHMENT_HTTP_STATUS.created, attachment);
+            return;
+        }
+
+        const attachmentId = decodeId(encodedAttachmentId, 'attachment');
+
+        if (isMemberRoute) {
+            if (request.method !== 'DELETE') {
+                sendJson(response, ATTACHMENT_HTTP_STATUS.methodNotAllowed, {
+                    error: 'method-not-allowed',
+                    message: 'Use DELETE to remove an attachment.',
+                });
+                return;
+            }
+
+            assertStateChangingRequest(request);
+            await deleteAttachment(itemId, attachmentId);
+            response.writeHead(ATTACHMENT_HTTP_STATUS.noContent, { 'Cache-Control': 'private, no-store' });
+            response.end();
+            return;
+        }
+
+        if (request.method !== 'GET') {
+            sendJson(response, ATTACHMENT_HTTP_STATUS.methodNotAllowed, {
+                error: 'method-not-allowed',
+                message: 'Use GET to download an attachment.',
+            });
+            return;
+        }
+
+        const attachment = await getReadyAttachment(itemId, attachmentId);
+        if (contentSegment === 'thumbnail') {
+            if (attachment.thumbnailId === undefined) {
+                throw new AttachmentRequestError(
+                    ATTACHMENT_HTTP_STATUS.notFound,
+                    'not-found',
+                    'The attachment thumbnail was not found.'
+                );
+            }
+            await streamAttachment(response, attachment.thumbnailId, 'image/jpeg', 'inline');
+        } else {
+            await streamAttachment(
+                response,
+                attachment.fileId,
+                attachment.mimeType,
+                buildAttachmentContentDisposition(attachment.originalFilename)
+            );
+        }
+    } catch (error) {
+        if (!response.headersSent) {
+            sendError(response, error);
+        } else {
+            logger.warn('Attachment request failed after headers were sent', error);
+            response.destroy();
+        }
+    }
+};
+
+export const registerAttachmentRoutes = (): void => {
+    webAppWithHandlers.handlers.use('/api/items', handleAttachmentRequest);
+};

--- a/meteor-app/server/attachmentService.test.ts
+++ b/meteor-app/server/attachmentService.test.ts
@@ -1,0 +1,172 @@
+import assert from 'assert';
+
+import { Meteor } from 'meteor/meteor';
+import { Random } from 'meteor/random';
+import sharp from 'sharp';
+
+import { Attachments } from '/imports/api/attachments';
+import { AttachmentRequestError } from '/imports/api/attachmentValidation';
+import { InventoryItemsCollection } from '/imports/api/items';
+import type { Attachment } from '/imports/model/Attachment';
+import type { InventoryItem } from '/imports/model/InventoryItem';
+import type NoId from '/imports/utility/NoId';
+
+import {
+    clearAttachmentStorage,
+    createAttachment,
+    deleteAttachment,
+    reconcileAttachmentStorage,
+} from './attachmentService';
+import { countGridFSFiles, getGridFSFileLength, initializeGridFS } from './gridfs';
+
+describe('attachmentService', function () {
+    const bindEnvironment = Meteor.bindEnvironment.bind(Meteor);
+    const tracerKey = '_attachmentTesting';
+    const tracer = { [tracerKey]: true };
+
+    const createTestItem = async (name = 'Attachment test item'): Promise<string> => {
+        const now = new Date();
+        const item: NoId<InventoryItem> & Record<string, unknown> = {
+            name,
+            isContainer: false,
+            tagIds: [],
+            createdAt: now,
+            modifiedAt: now,
+            ...tracer,
+        };
+        return await InventoryItemsCollection.insertAsync(item);
+    };
+
+    this.beforeAll(
+        bindEnvironment(async () => {
+            initializeGridFS();
+            await clearAttachmentStorage();
+            await InventoryItemsCollection.removeAsync({ [tracerKey]: { $exists: true } });
+        })
+    );
+
+    this.afterEach(
+        bindEnvironment(async () => {
+            await clearAttachmentStorage();
+            await InventoryItemsCollection.removeAsync({ [tracerKey]: { $exists: true } });
+        })
+    );
+
+    it('stores a validated image, thumbnail, and ready metadata', async function () {
+        const itemId = await createTestItem();
+        const image = await sharp({
+            create: { width: 8, height: 6, channels: 3, background: { r: 20, g: 40, b: 60 } },
+        })
+            .png()
+            .toBuffer();
+
+        const attachment = await createAttachment(itemId, encodeURIComponent('photo.png'), image);
+
+        assert.strictEqual(attachment.storageState, 'ready');
+        assert.strictEqual(attachment.type, 'photo');
+        assert.strictEqual(attachment.mimeType, 'image/png');
+        assert.strictEqual(attachment.width, 8);
+        assert.strictEqual(attachment.height, 6);
+        assert.ok(attachment.thumbnailId);
+        assert.strictEqual(await getGridFSFileLength(attachment.fileId), image.length);
+        assert.ok((await getGridFSFileLength(attachment.thumbnailId)) !== undefined);
+        assert.strictEqual(await countGridFSFiles(), 2);
+
+        const stored = await Attachments.findOneAsync({ _id: attachment._id });
+        assert.strictEqual(stored?.storageState, 'ready');
+    });
+
+    it('stores a PDF without a thumbnail', async function () {
+        const itemId = await createTestItem();
+        const pdf = Buffer.from('%PDF-1.4\nminimal fixture\n%%EOF');
+
+        const attachment = await createAttachment(itemId, encodeURIComponent('receipt.pdf'), pdf);
+
+        assert.strictEqual(attachment.type, 'pdf');
+        assert.strictEqual(attachment.thumbnailId, undefined);
+        assert.strictEqual(await countGridFSFiles(), 1);
+    });
+
+    it('rejects unsupported bytes without allocating storage', async function () {
+        const itemId = await createTestItem();
+
+        await assert.rejects(
+            async () => await createAttachment(itemId, encodeURIComponent('fake.png'), Buffer.from('not an image')),
+            (error: unknown) =>
+                error instanceof AttachmentRequestError && error.status === 400 && error.code === 'unsupported-file'
+        );
+
+        assert.strictEqual(await Attachments.find({ itemId }).countAsync(), 0);
+        assert.strictEqual(await countGridFSFiles(), 0);
+    });
+
+    it('deletes metadata and all owned blobs', async function () {
+        const itemId = await createTestItem();
+        const image = await sharp({
+            create: { width: 4, height: 4, channels: 3, background: { r: 1, g: 2, b: 3 } },
+        })
+            .jpeg()
+            .toBuffer();
+        const attachment = await createAttachment(itemId, encodeURIComponent('photo.jpg'), image);
+
+        await deleteAttachment(itemId, attachment._id);
+
+        assert.strictEqual(await Attachments.find({ _id: attachment._id }).countAsync(), 0);
+        assert.strictEqual(await countGridFSFiles(), 0);
+    });
+
+    it('does not delete an attachment through a different item ID', async function () {
+        const itemId = await createTestItem('Owner');
+        const otherItemId = await createTestItem('Other');
+        const attachment = await createAttachment(
+            itemId,
+            encodeURIComponent('receipt.pdf'),
+            Buffer.from('%PDF-1.4\nfixture\n%%EOF')
+        );
+
+        await assert.rejects(
+            async () => {
+                await deleteAttachment(otherItemId, attachment._id);
+            },
+            (error: unknown) =>
+                error instanceof AttachmentRequestError && error.status === 404 && error.code === 'not-found'
+        );
+
+        assert.strictEqual(await Attachments.find({ _id: attachment._id, storageState: 'ready' }).countAsync(), 1);
+        assert.strictEqual(await countGridFSFiles(), 1);
+    });
+
+    it('reconciles interrupted uploading and deleting records', async function () {
+        const itemId = await createTestItem();
+        const ready = await createAttachment(
+            itemId,
+            encodeURIComponent('receipt.pdf'),
+            Buffer.from('%PDF-1.4\nfixture\n%%EOF')
+        );
+        await Attachments.updateAsync({ _id: ready._id }, { $set: { storageState: 'deleting' } });
+
+        const now = new Date();
+        const interruptedUpload: Attachment = {
+            _id: Random.id(),
+            itemId,
+            type: 'pdf',
+            fileId: '507f1f77bcf86cd799439011',
+            storageState: 'uploading',
+            label: 'pending.pdf',
+            originalFilename: 'pending.pdf',
+            mimeType: 'application/pdf',
+            fileSize: 10,
+            order: 1,
+            isPrimary: false,
+            createdAt: now,
+            modifiedAt: now,
+        };
+        await Attachments.insertAsync(interruptedUpload);
+
+        const result = await reconcileAttachmentStorage();
+
+        assert.deepStrictEqual(result, { uploadsRemoved: 1, deletesFinished: 1 });
+        assert.strictEqual(await Attachments.find({ itemId }).countAsync(), 0);
+        assert.strictEqual(await countGridFSFiles(), 0);
+    });
+});

--- a/meteor-app/server/attachmentService.ts
+++ b/meteor-app/server/attachmentService.ts
@@ -1,0 +1,274 @@
+/**
+ * Recoverable metadata-and-blob lifecycle for item attachments.
+ * Coordinates staged MongoDB records with reserved GridFS IDs; HTTP parsing and
+ * UI concerns stay outside this module so cleanup invariants remain testable.
+ */
+import { Random } from 'meteor/random';
+
+import { Attachments } from '/imports/api/attachments';
+import {
+    ATTACHMENT_HTTP_STATUS,
+    AttachmentRequestError,
+    decodeAndSanitizeFilename,
+    detectAttachmentType,
+    MAX_ATTACHMENT_BYTES,
+} from '/imports/api/attachmentValidation';
+import { InventoryItemsCollection } from '/imports/api/items';
+import type { Attachment } from '/imports/model/Attachment';
+import createLogger from '/imports/utility/Logger';
+
+import {
+    clearGridFSBucket,
+    createGridFSFileId,
+    deleteFromGridFSIfExists,
+    getGridFSFileLength,
+    uploadToGridFS,
+} from './gridfs';
+import { generateThumbnail, getImageMetadata } from './imageProcessing';
+
+const logger = createLogger(module);
+
+const cleanupAttachmentBlobs = async (attachment: Attachment): Promise<void> => {
+    await deleteFromGridFSIfExists(attachment.fileId);
+
+    if (attachment.thumbnailId !== undefined) {
+        await deleteFromGridFSIfExists(attachment.thumbnailId);
+    }
+};
+
+const getNextAttachmentOrder = async (itemId: string): Promise<number> => {
+    const latest = await Attachments.findOneAsync({ itemId, storageState: 'ready' }, { sort: { order: -1 } });
+    return latest === undefined ? 0 : latest.order + 1;
+};
+
+const hasPrimaryPhoto = async (itemId: string): Promise<boolean> => {
+    return (await Attachments.find({ itemId, type: 'photo', isPrimary: true, storageState: 'ready' }).countAsync()) > 0;
+};
+
+export const createAttachment = async (
+    itemId: string,
+    encodedFilename: string | undefined,
+    bytes: Buffer
+): Promise<Attachment> => {
+    if (bytes.length === 0) {
+        throw new AttachmentRequestError(
+            ATTACHMENT_HTTP_STATUS.badRequest,
+            'invalid-request',
+            'The attachment file is empty.'
+        );
+    }
+
+    if (bytes.length > MAX_ATTACHMENT_BYTES) {
+        throw new AttachmentRequestError(
+            ATTACHMENT_HTTP_STATUS.contentTooLarge,
+            'file-too-large',
+            'Attachments must be 20 MiB or smaller.'
+        );
+    }
+
+    const item = await InventoryItemsCollection.findOneAsync({ _id: itemId });
+    if (item === undefined) {
+        throw new AttachmentRequestError(
+            ATTACHMENT_HTTP_STATUS.notFound,
+            'not-found',
+            'The inventory item was not found.'
+        );
+    }
+
+    const filename = decodeAndSanitizeFilename(encodedFilename);
+    const validatedType = detectAttachmentType(bytes);
+
+    let thumbnail: Buffer | undefined = undefined;
+    let width: number | undefined = undefined;
+    let height: number | undefined = undefined;
+    let exifOrientation: number | undefined = undefined;
+
+    if (validatedType.type === 'photo') {
+        try {
+            const metadata = await getImageMetadata(bytes);
+            thumbnail = await generateThumbnail(bytes);
+            width = metadata.width;
+            height = metadata.height;
+            exifOrientation = metadata.orientation;
+        } catch {
+            throw new AttachmentRequestError(
+                ATTACHMENT_HTTP_STATUS.badRequest,
+                'unsupported-file',
+                'Choose a valid JPEG or PNG image.'
+            );
+        }
+    }
+
+    const now = new Date();
+    const attachmentId = Random.id();
+    const fileId = createGridFSFileId();
+    const thumbnailId = thumbnail === undefined ? undefined : createGridFSFileId();
+    const attachment: Attachment = {
+        _id: attachmentId,
+        itemId,
+        type: validatedType.type,
+        fileId,
+        thumbnailId,
+        storageState: 'uploading',
+        label: filename,
+        originalFilename: filename,
+        mimeType: validatedType.mimeType,
+        fileSize: bytes.length,
+        order: await getNextAttachmentOrder(itemId),
+        isPrimary: validatedType.type === 'photo' && !(await hasPrimaryPhoto(itemId)),
+        width,
+        height,
+        exifOrientation,
+        createdAt: now,
+        modifiedAt: now,
+    };
+
+    await Attachments.insertAsync(attachment);
+
+    try {
+        await uploadToGridFS(
+            bytes,
+            filename,
+            { attachmentId, itemId, role: 'original', mimeType: validatedType.mimeType },
+            fileId
+        );
+
+        if (thumbnail !== undefined && thumbnailId !== undefined) {
+            await uploadToGridFS(
+                thumbnail,
+                `${filename}.thumbnail.jpg`,
+                { attachmentId, itemId, role: 'thumbnail', mimeType: 'image/jpeg' },
+                thumbnailId
+            );
+        }
+
+        const readyAt = new Date();
+        const updated = await Attachments.updateAsync(
+            { _id: attachmentId, storageState: 'uploading' },
+            { $set: { storageState: 'ready', modifiedAt: readyAt } }
+        );
+
+        if (updated !== 1) {
+            throw new Error('Attachment metadata did not enter the ready state.');
+        }
+
+        return { ...attachment, storageState: 'ready', modifiedAt: readyAt };
+    } catch (error) {
+        try {
+            await cleanupAttachmentBlobs(attachment);
+            await Attachments.removeAsync({ _id: attachmentId, storageState: 'uploading' });
+        } catch (cleanupError) {
+            logger.warn('Attachment upload compensation failed', {
+                attachmentId,
+                itemId,
+                error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+            });
+        }
+
+        logger.warn('Attachment upload failed', {
+            attachmentId,
+            itemId,
+            error: error instanceof Error ? error.message : String(error),
+        });
+        throw new AttachmentRequestError(
+            ATTACHMENT_HTTP_STATUS.internalServerError,
+            'storage-error',
+            'The attachment could not be stored.'
+        );
+    }
+};
+
+export const getReadyAttachment = async (itemId: string, attachmentId: string): Promise<Attachment> => {
+    const attachment = await Attachments.findOneAsync({
+        _id: attachmentId,
+        itemId,
+        storageState: 'ready',
+    });
+
+    if (attachment === undefined) {
+        throw new AttachmentRequestError(ATTACHMENT_HTTP_STATUS.notFound, 'not-found', 'The attachment was not found.');
+    }
+
+    return attachment;
+};
+
+export const assertAttachmentBlobExists = async (fileId: string): Promise<number> => {
+    const length = await getGridFSFileLength(fileId);
+    if (length === undefined) {
+        throw new AttachmentRequestError(
+            ATTACHMENT_HTTP_STATUS.notFound,
+            'not-found',
+            'The attachment file was not found.'
+        );
+    }
+    return length;
+};
+
+export const deleteAttachment = async (itemId: string, attachmentId: string): Promise<void> => {
+    const attachment = await Attachments.findOneAsync({ _id: attachmentId, itemId });
+
+    if (attachment === undefined) {
+        throw new AttachmentRequestError(ATTACHMENT_HTTP_STATUS.notFound, 'not-found', 'The attachment was not found.');
+    }
+
+    if (attachment.storageState === 'uploading') {
+        throw new AttachmentRequestError(
+            ATTACHMENT_HTTP_STATUS.conflict,
+            'storage-conflict',
+            'The attachment upload is still being finalized.'
+        );
+    }
+
+    if (attachment.storageState === 'ready') {
+        await Attachments.updateAsync(
+            { _id: attachmentId, itemId, storageState: 'ready' },
+            { $set: { storageState: 'deleting', modifiedAt: new Date() } }
+        );
+    }
+
+    try {
+        await cleanupAttachmentBlobs(attachment);
+        await Attachments.removeAsync({ _id: attachmentId, itemId, storageState: 'deleting' });
+    } catch (error) {
+        logger.warn('Attachment deletion failed', {
+            attachmentId,
+            itemId,
+            error: error instanceof Error ? error.message : String(error),
+        });
+        throw new AttachmentRequestError(
+            ATTACHMENT_HTTP_STATUS.internalServerError,
+            'storage-error',
+            'The attachment could not be deleted.'
+        );
+    }
+};
+
+export const reconcileAttachmentStorage = async (): Promise<{ uploadsRemoved: number; deletesFinished: number }> => {
+    const interrupted = await Attachments.find({ storageState: { $in: ['uploading', 'deleting'] } }).fetchAsync();
+    let uploadsRemoved = 0;
+    let deletesFinished = 0;
+
+    for (const attachment of interrupted) {
+        try {
+            await cleanupAttachmentBlobs(attachment);
+            await Attachments.removeAsync({ _id: attachment._id, storageState: attachment.storageState });
+            if (attachment.storageState === 'uploading') uploadsRemoved++;
+            else deletesFinished++;
+        } catch (error) {
+            logger.warn('Attachment startup reconciliation failed', {
+                attachmentId: attachment._id,
+                itemId: attachment.itemId,
+                state: attachment.storageState,
+                error: error instanceof Error ? error.message : String(error),
+            });
+        }
+    }
+
+    return { uploadsRemoved, deletesFinished };
+};
+
+export const clearAttachmentStorage = async (): Promise<{ filesRemoved: number; recordsRemoved: number }> => {
+    const filesRemoved = await clearGridFSBucket();
+    const recordsRemoved = await Attachments.removeAsync({});
+    return { filesRemoved, recordsRemoved };
+};

--- a/meteor-app/server/gridfs.ts
+++ b/meteor-app/server/gridfs.ts
@@ -1,3 +1,8 @@
+/**
+ * Low-level GridFS access for attachment blobs.
+ * Centralizes ObjectId conversion and idempotent blob operations so lifecycle
+ * services can coordinate MongoDB metadata without duplicating driver details.
+ */
 import { MongoInternals } from 'meteor/mongo';
 import type { GridFSBucket as GridFSBucketType, GridFSBucketReadStream, ObjectId } from 'mongodb';
 
@@ -70,6 +75,11 @@ const toObjectId = (fileId: string): ObjectId => {
     return new ObjectIdConstructor(fileId) as unknown as ObjectId;
 };
 
+export const createGridFSFileId = (): string => {
+    const { ObjectId: ObjectIdConstructor } = MongoInternals.NpmModules.mongodb.module;
+    return new ObjectIdConstructor().toString();
+};
+
 /**
  * Upload a file to GridFS.
  *
@@ -90,12 +100,16 @@ const toObjectId = (fileId: string): ObjectId => {
 export const uploadToGridFS = async (
     buffer: Buffer,
     filename: string,
-    metadata: Record<string, unknown> = {}
+    metadata: Record<string, unknown> = {},
+    reservedFileId?: string
 ): Promise<string> => {
     const bucket = getGridFSBucket();
 
     return await new Promise<string>((resolve, reject) => {
-        const uploadStream = bucket.openUploadStream(filename, { metadata });
+        const uploadStream =
+            reservedFileId === undefined
+                ? bucket.openUploadStream(filename, { metadata })
+                : bucket.openUploadStreamWithId(toObjectId(reservedFileId), filename, { metadata });
 
         uploadStream.on('error', reject);
         uploadStream.on('finish', () => {
@@ -105,6 +119,17 @@ export const uploadToGridFS = async (
         uploadStream.write(buffer);
         uploadStream.end();
     });
+};
+
+export const getGridFSFileLength = async (fileId: string): Promise<number | undefined> => {
+    const bucket = getGridFSBucket();
+    const file = await bucket.find({ _id: toObjectId(fileId) }).next();
+    return file?.length;
+};
+
+export const countGridFSFiles = async (): Promise<number> => {
+    const bucket = getGridFSBucket();
+    return (await bucket.find({}).toArray()).length;
 };
 
 /**
@@ -144,4 +169,31 @@ export const downloadFromGridFS = (fileId: string): GridFSBucketReadStream => {
 export const deleteFromGridFS = async (fileId: string): Promise<void> => {
     const bucket = getGridFSBucket();
     await bucket.delete(toObjectId(fileId));
+};
+
+export const deleteFromGridFSIfExists = async (fileId: string): Promise<void> => {
+    const bucket = getGridFSBucket();
+    const objectId = toObjectId(fileId);
+    const exists = await bucket.find({ _id: objectId }).hasNext();
+
+    if (exists) {
+        try {
+            await bucket.delete(objectId);
+        } catch (error) {
+            if (!(error instanceof Error) || !/File not found/iu.test(error.message)) {
+                throw error;
+            }
+        }
+    }
+};
+
+export const clearGridFSBucket = async (): Promise<number> => {
+    const bucket = getGridFSBucket();
+    const files = await bucket.find({}).toArray();
+
+    for (const file of files) {
+        await bucket.delete(file._id);
+    }
+
+    return files.length;
 };

--- a/meteor-app/server/main.ts
+++ b/meteor-app/server/main.ts
@@ -15,6 +15,8 @@ import {
 } from '/imports/api/tags';
 import createLogger from '/imports/utility/Logger';
 
+import { registerAttachmentRoutes } from './attachmentRoutes';
+import { reconcileAttachmentStorage } from './attachmentService';
 import { initializeGridFS } from './gridfs';
 import '/imports/api/importExport/export';
 import '/imports/api/importExport/import';
@@ -23,11 +25,17 @@ import './test-helpers'; // Test helper methods for E2E testing
 
 const logger = createLogger(module);
 
+registerAttachmentRoutes();
+
 Meteor.startup(async () => {
     Meteor.settings.fixPath = true;
 
     // Initialize GridFS bucket for file storage (T009)
     initializeGridFS();
+    const reconciliation = await reconcileAttachmentStorage();
+    if (reconciliation.uploadsRemoved > 0 || reconciliation.deletesFinished > 0) {
+        logger.log('Reconciled interrupted attachment storage', reconciliation);
+    }
 
     // Create database indexes for performance
     logger.log('Creating database indexes...');
@@ -46,7 +54,7 @@ Meteor.startup(async () => {
     await TagsCollection.createIndexAsync({ path: 1 }); // Hierarchy queries
 
     // Attachments collection indexes (T008)
-    await Attachments.createIndexAsync({ itemId: 1, order: 1 }); // Ordered list per item
+    await Attachments.createIndexAsync({ itemId: 1, storageState: 1, order: 1 }); // Ready ordered list per item
     await Attachments.createIndexAsync({ itemId: 1, type: 1 }); // Filter by type
     await Attachments.createIndexAsync({ fileId: 1 }); // GridFS lookup
 

--- a/meteor-app/server/test-helpers.ts
+++ b/meteor-app/server/test-helpers.ts
@@ -8,10 +8,12 @@ import type { IncomingMessage, ServerResponse } from 'http';
 import { Meteor } from 'meteor/meteor';
 import { WebApp } from 'meteor/webapp';
 
+import { Attachments } from '/imports/api/attachments';
 import Items from '/imports/api/items';
 import Tags from '/imports/api/tags';
 
 import { clearAttachmentStorage } from './attachmentService';
+import { countGridFSFiles } from './gridfs';
 
 // HTTP status codes
 const HTTP_OK = 200;
@@ -115,6 +117,31 @@ if (!Meteor.isProduction) {
             await resetDatabase();
             res.writeHead(HTTP_OK, { 'Content-Type': 'application/json' });
             res.end(JSON.stringify({ success: true }));
+        } catch (error) {
+            res.writeHead(HTTP_INTERNAL_SERVER_ERROR, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: error instanceof Error ? error.message : 'Unknown error' }));
+        }
+    });
+
+    /**
+     * Storage-level attachment counts for E2E lifecycle assertions.
+     * Kept behind the same explicit throwaway-database guard as reset.
+     */
+    webAppWithHandlers.handlers.use('/api/test/attachment-storage', async (req, res) => {
+        if (req.method !== 'GET') {
+            res.writeHead(HTTP_METHOD_NOT_ALLOWED, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Method not allowed. Use GET.' }));
+            return;
+        }
+
+        try {
+            assertTestDatabaseMutationAllowed();
+            const [metadataCount, fileCount] = await Promise.all([
+                Attachments.find({}).countAsync(),
+                countGridFSFiles(),
+            ]);
+            res.writeHead(HTTP_OK, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
+            res.end(JSON.stringify({ metadataCount, fileCount }));
         } catch (error) {
             res.writeHead(HTTP_INTERNAL_SERVER_ERROR, { 'Content-Type': 'application/json' });
             res.end(JSON.stringify({ error: error instanceof Error ? error.message : 'Unknown error' }));

--- a/meteor-app/server/test-helpers.ts
+++ b/meteor-app/server/test-helpers.ts
@@ -8,9 +8,10 @@ import type { IncomingMessage, ServerResponse } from 'http';
 import { Meteor } from 'meteor/meteor';
 import { WebApp } from 'meteor/webapp';
 
-import { Attachments } from '/imports/api/attachments';
 import Items from '/imports/api/items';
 import Tags from '/imports/api/tags';
+
+import { clearAttachmentStorage } from './attachmentService';
 
 // HTTP status codes
 const HTTP_OK = 200;
@@ -61,12 +62,10 @@ const assertTestDatabaseMutationAllowed = (): void => {
 async function resetDatabase(): Promise<void> {
     assertTestDatabaseMutationAllowed();
 
-    // Remove all documents from all collections
+    // Remove blobs before their item records so failed cleanup remains retryable.
+    await clearAttachmentStorage();
     await Items.removeAsync({});
     await Tags.removeAsync({});
-    await Attachments.removeAsync({});
-
-    // TODO: Also clear GridFS files when attachments are implemented
 }
 
 // Export methods only in development

--- a/specs/005-item-attachments/contracts/attachment-lifecycle.md
+++ b/specs/005-item-attachments/contracts/attachment-lifecycle.md
@@ -1,0 +1,176 @@
+# Attachment Lifecycle Contract
+
+## Scope
+
+This contract defines the first usable attachment slice for inventory items. It
+supports one JPEG, PNG, or PDF upload at a time, metadata listing, downloading,
+and deletion. The maximum original-file size is 20 MiB (20 × 1024 × 1024
+bytes).
+
+The first slice deliberately excludes HEIC/HEIF, batch upload, reordering,
+primary-photo selection, custom labels, rich viewers, item duplication,
+resumable upload, and backup bundles containing blobs. Those capabilities remain
+tracked by `bd-k9s.5` and must not be inferred from fields already present in the
+model.
+
+## Trust boundary
+
+The application currently has no accounts or per-user ownership model. Version
+1 attachment endpoints therefore share the existing single-user application's
+deployment boundary; they do not create an authentication boundary of their
+own. A deployment must remain behind the same localhost, VPN, reverse-proxy, or
+private-network control used to protect the rest of the inventory.
+
+Within that boundary, every operation still validates both the item and the
+attachment relationship. Supplying an attachment ID with a different item ID
+must return `404`, not expose or mutate the other item's file. Remote multi-user
+authorization is out of scope until the application has an identity model.
+
+State-changing HTTP requests require the non-simple
+`X-Inventory-Attachment-Request: 1` header and same-origin requests. This blocks
+ordinary cross-origin form submission, but it is CSRF hardening rather than
+authentication. The server does not opt attachment routes into cross-origin
+resource sharing.
+
+## Stored record
+
+Attachment metadata remains in the `attachments` MongoDB collection and file
+bytes remain in the `attachments` GridFS bucket. Each metadata record owns one
+original blob and, for images, one server-generated JPEG thumbnail.
+
+The metadata record includes a storage state:
+
+- `uploading`: invisible to normal clients; fixed blob IDs have been reserved
+  and the upload is incomplete.
+- `ready`: visible and downloadable; the original blob and any thumbnail exist.
+- `deleting`: invisible to normal clients; blob and metadata cleanup may be
+  retried idempotently.
+
+GridFS file metadata includes `attachmentId`, `itemId`, and `role` (`original`
+or `thumbnail`). This makes interrupted operations discoverable without trusting
+filenames.
+
+Normal publications return only `ready` records. They never publish file bytes.
+The public metadata shape contains the attachment ID, item ID, type, canonical
+MIME type, byte size, label/original filename, order, primary flag, image
+dimensions when available, and timestamps.
+
+## Upload request
+
+`POST /api/items/:itemId/attachments`
+
+Headers:
+
+- `X-Inventory-Attachment-Request: 1`
+- `X-Inventory-Filename`: `encodeURIComponent(file.name)`
+- `Content-Type`: the browser-declared media type (advisory only)
+- `Content-Length`: optional; values above 20 MiB are rejected before reading
+
+The request body is the raw file. Empty bodies are invalid. The server reads at
+most 20 MiB plus one byte so chunked requests cannot bypass the limit.
+
+The server determines the canonical type from bytes, never from the filename or
+declared `Content-Type`:
+
+- JPEG begins `FF D8 FF`.
+- PNG begins `89 50 4E 47 0D 0A 1A 0A`.
+- PDF begins `%PDF-` at byte zero.
+
+JPEG and PNG candidates must also decode successfully with Sharp before any
+ready record is exposed. A decoded image receives a server-generated JPEG
+thumbnail with EXIF orientation applied. PDF originals are stored without a
+thumbnail. Unsupported, mismatched, malformed, or polyglot-looking inputs are
+rejected with a stable `400` error and no ready metadata.
+
+The original filename is decoded strictly, normalized to Unicode NFC, stripped
+of control characters and path separators, trimmed, and capped at 255 Unicode
+code points. An empty result becomes `attachment`. The first slice uses that
+safe value as both `label` and `originalFilename`.
+
+Successful upload returns `201` and the ready metadata object. Client errors
+return JSON with a stable `error` code and human-readable `message`.
+
+## Listing and file responses
+
+`attachments.byItem(itemId)` publishes ready metadata for an existing item,
+ordered by `order`, then creation time and ID. An invalid or missing item ID
+publishes nothing.
+
+`GET /api/items/:itemId/attachments/:attachmentId/content` downloads the
+original only after the item/attachment relationship and `ready` state are
+confirmed.
+
+`GET /api/items/:itemId/attachments/:attachmentId/thumbnail` returns the
+generated thumbnail and returns `404` for PDFs or missing thumbnails.
+
+Original downloads use:
+
+- the canonical media type;
+- `Content-Disposition: attachment` with a quoted ASCII fallback plus RFC 5987
+  `filename*=UTF-8''...`;
+- `X-Content-Type-Options: nosniff`;
+- `Cache-Control: private, no-store`.
+
+Thumbnails use `image/jpeg`, `Content-Disposition: inline`, `nosniff`, and the
+same private no-store policy. Stream errors must terminate the response without
+exposing server details.
+
+## Delete request
+
+`DELETE /api/items/:itemId/attachments/:attachmentId`
+
+The request requires `X-Inventory-Attachment-Request: 1`. A ready record first
+moves to `deleting`, hiding it from clients. The server then deletes the original
+and thumbnail blobs and finally removes the metadata record. Missing GridFS
+files are treated as already deleted. Repeating deletion of a record already in
+`deleting` retries cleanup. A fully absent or mismatched record returns `404`.
+
+Successful deletion returns `204` with no body.
+
+## Failure and recovery invariants
+
+Upload reserves fixed blob IDs in an `uploading` record before writing bytes.
+Only after all required blobs exist does one metadata update make the record
+`ready`. Any ordinary upload failure runs compensation immediately. A startup
+reconciler also removes stale `uploading` records and their reserved blobs, and
+finishes stale `deleting` records, so a process interruption is recoverable.
+
+Deletion never removes metadata first. This preserves the blob IDs needed for
+retry. GridFS "file not found" during cleanup is success; other storage errors
+leave the record in a retryable non-ready state and are logged using IDs only.
+
+The explicit E2E reset path deletes attachment metadata and all files in the
+attachments GridFS bucket. Tests must prove that rejected uploads, successful
+deletes, and resets leave neither attachment documents nor GridFS files behind.
+
+## Backup and export compatibility
+
+CSV and the current JSON data export continue to omit attachment bytes. Future
+backup export must enumerate `ready` attachment metadata, retrieve blobs by
+`fileId`/`thumbnailId`, and preserve the association by attachment and item IDs.
+Non-ready records must never enter a backup. A future import must allocate new
+GridFS IDs and use the same staged lifecycle instead of inserting trusted IDs
+from an archive.
+
+## Error mapping
+
+| Status | Code | Meaning |
+| --- | --- | --- |
+| `400` | `invalid-request` | Missing/invalid IDs, filename header, request marker, empty body, malformed encoding, or invalid route shape |
+| `400` | `unsupported-file` | Bytes are not a supported JPEG, PNG, or PDF, or an image cannot be decoded |
+| `413` | `file-too-large` | Declared or observed body exceeds 20 MiB |
+| `404` | `not-found` | Item, attachment relationship, ready content, or thumbnail does not exist |
+| `405` | `method-not-allowed` | Route exists but the method is unsupported |
+| `409` | `storage-conflict` | A retryable non-ready lifecycle state prevents the requested transition |
+| `500` | `storage-error` | Storage work failed; response omits internal details and state remains recoverable |
+
+## Verification fixtures
+
+Tests use tiny deterministic byte fixtures: a valid JPEG, valid PNG, valid PDF,
+plain text with a forged image MIME type, a truncated image signature, an empty
+body, and a generated 20 MiB plus one byte body. Filenames include ordinary
+ASCII, Unicode, path separators, quotes, CR/LF, and an encoded malformed value.
+
+The complete app flow is exercised only against the disposable Meteor database
+guarded by `E2E_RESET_DATABASE=1`; tests must never point reset or attachment
+mutation fixtures at `NAS_MONGO_URL`.

--- a/tests/e2e/app/attachments.spec.ts
+++ b/tests/e2e/app/attachments.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * Browser-level attachment lifecycle coverage for item details and runtime routes.
+ * Verifies UI behavior, content safety, ownership boundaries, and physical blob cleanup.
+ */
+import { expect, test, type APIResponse, type Page } from '@playwright/test';
+
+import { getAttachmentStorageStats, resetDatabase, waitForMeteorReady } from '../helpers/database';
+import { createItem } from '../helpers/factories';
+
+const PDF_BYTES = Buffer.from('%PDF-1.7\nattachment e2e fixture\n%%EOF');
+const PNG_BYTES = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+    'base64'
+);
+const MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024;
+
+interface AttachmentResponse {
+    _id: string;
+    itemId: string;
+    originalFilename: string;
+    mimeType: string;
+}
+
+const attachmentCollectionUrl = (itemId: string): string => `/api/items/${itemId}/attachments`;
+const attachmentMemberUrl = (itemId: string, attachmentId: string): string =>
+    `${attachmentCollectionUrl(itemId)}/${attachmentId}`;
+const attachmentContentUrl = (itemId: string, attachmentId: string, target = 'content'): string =>
+    `${attachmentMemberUrl(itemId, attachmentId)}/${target}`;
+
+async function uploadAttachment(
+    page: Page,
+    itemId: string,
+    filename: string,
+    mimeType: string,
+    bytes: Buffer
+): Promise<{ attachment: AttachmentResponse; response: APIResponse }> {
+    const response = await page.request.post(attachmentCollectionUrl(itemId), {
+        headers: {
+            'Content-Type': mimeType,
+            'X-Inventory-Attachment-Request': '1',
+            'X-Inventory-Filename': encodeURIComponent(filename),
+        },
+        data: bytes,
+    });
+    const attachment = (await response.json()) as AttachmentResponse;
+    return { attachment, response };
+}
+
+test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForMeteorReady(page);
+    await resetDatabase(page);
+    await expect.poll(async () => await getAttachmentStorageStats(page)).toEqual({ metadataCount: 0, fileCount: 0 });
+});
+
+test.describe('Item attachments', () => {
+    test('uploads, downloads, and deletes a PDF through item details', async ({ page }) => {
+        const itemId = await createItem(page, { name: 'Attachment Manual' });
+        await page.goto(`/items/${itemId}`);
+        await expect(page.getByRole('heading', { name: 'Attachment Manual' })).toBeVisible();
+
+        await page.getByTestId('attachment-file-input').setInputFiles({
+            name: 'warranty manual.pdf',
+            mimeType: 'application/pdf',
+            buffer: PDF_BYTES,
+        });
+        await page.getByRole('button', { name: 'Upload attachment' }).click();
+
+        const attachmentRow = page.getByTestId('attachment-row').filter({ hasText: 'warranty manual.pdf' });
+        await expect(attachmentRow).toBeVisible();
+        await expect
+            .poll(async () => await getAttachmentStorageStats(page))
+            .toEqual({ metadataCount: 1, fileCount: 1 });
+
+        const contentUrl = await attachmentRow.getByRole('link', { name: 'Download' }).getAttribute('href');
+        expect(contentUrl).not.toBeNull();
+        const downloadResponse = await page.request.get(contentUrl ?? '');
+        expect(downloadResponse.status()).toBe(200);
+        expect(downloadResponse.headers()['content-type']).toContain('application/pdf');
+        expect(downloadResponse.headers()['content-disposition']).toContain('filename="warranty manual.pdf"');
+        expect(downloadResponse.headers()['content-disposition']).toContain("filename*=UTF-8''warranty%20manual.pdf");
+        expect(await downloadResponse.body()).toEqual(PDF_BYTES);
+
+        await attachmentRow.getByRole('button', { name: 'Delete' }).click();
+        await expect(attachmentRow.getByText(/cannot be undone/)).toBeVisible();
+        await attachmentRow.getByRole('button', { name: 'Delete attachment' }).click();
+
+        await expect(attachmentRow).toHaveCount(0);
+        await expect
+            .poll(async () => await getAttachmentStorageStats(page))
+            .toEqual({ metadataCount: 0, fileCount: 0 });
+    });
+
+    test('renders an image thumbnail and reset removes both image blobs', async ({ page }) => {
+        const itemId = await createItem(page, { name: 'Attachment Photo' });
+        await page.goto(`/items/${itemId}`);
+
+        await page.getByTestId('attachment-file-input').setInputFiles({
+            name: 'shelf.png',
+            mimeType: 'image/png',
+            buffer: PNG_BYTES,
+        });
+        await page.getByRole('button', { name: 'Upload attachment' }).click();
+
+        const attachmentRow = page.getByTestId('attachment-row').filter({ hasText: 'shelf.png' });
+        const preview = attachmentRow.getByRole('img', { name: 'Preview of shelf.png' });
+        await expect(preview).toBeVisible();
+        await expect.poll(async () => await preview.evaluate((image: HTMLImageElement) => image.complete)).toBe(true);
+        await expect
+            .poll(async () => await getAttachmentStorageStats(page))
+            .toEqual({ metadataCount: 1, fileCount: 2 });
+
+        await resetDatabase(page);
+        await expect
+            .poll(async () => await getAttachmentStorageStats(page))
+            .toEqual({ metadataCount: 0, fileCount: 0 });
+    });
+
+    test('rejects forged and oversized files without allocating storage', async ({ page }) => {
+        const itemId = await createItem(page, { name: 'Attachment Validation' });
+        await page.goto(`/items/${itemId}`);
+
+        await page.getByTestId('attachment-file-input').setInputFiles({
+            name: 'forged.png',
+            mimeType: 'image/png',
+            buffer: Buffer.from('not actually an image'),
+        });
+        await page.getByRole('button', { name: 'Upload attachment' }).click();
+        await expect(page.getByTestId('attachment-error')).toContainText('valid JPEG, PNG, or PDF');
+        await expect(page.getByTestId('attachment-row')).toHaveCount(0);
+        await expect
+            .poll(async () => await getAttachmentStorageStats(page))
+            .toEqual({ metadataCount: 0, fileCount: 0 });
+
+        await page.getByTestId('attachment-file-input').setInputFiles({
+            name: 'too-large.png',
+            mimeType: 'image/png',
+            buffer: Buffer.alloc(MAX_ATTACHMENT_BYTES + 1),
+        });
+        await expect(page.getByTestId('attachment-selection-error')).toContainText('20 MiB or smaller');
+        await expect(page.getByRole('button', { name: 'Upload attachment' })).toBeDisabled();
+
+        const oversizedResponse = await page.request.post(attachmentCollectionUrl(itemId), {
+            headers: {
+                'Content-Type': 'image/png',
+                'X-Inventory-Attachment-Request': '1',
+                'X-Inventory-Filename': encodeURIComponent('too-large.png'),
+            },
+            data: Buffer.alloc(MAX_ATTACHMENT_BYTES + 1),
+        });
+        expect(oversizedResponse.status()).toBe(413);
+        await expect
+            .poll(async () => await getAttachmentStorageStats(page))
+            .toEqual({ metadataCount: 0, fileCount: 0 });
+    });
+
+    test('enforces item ownership on runtime download and delete routes', async ({ page }) => {
+        const ownerItemId = await createItem(page, { name: 'Attachment Owner' });
+        const otherItemId = await createItem(page, { name: 'Other Item' });
+        const { attachment, response } = await uploadAttachment(
+            page,
+            ownerItemId,
+            'owner.pdf',
+            'application/pdf',
+            PDF_BYTES
+        );
+        expect(response.status()).toBe(201);
+
+        const mismatchedDownload = await page.request.get(attachmentContentUrl(otherItemId, attachment._id));
+        expect(mismatchedDownload.status()).toBe(404);
+        const mismatchedDelete = await page.request.delete(attachmentMemberUrl(otherItemId, attachment._id), {
+            headers: { 'X-Inventory-Attachment-Request': '1' },
+        });
+        expect(mismatchedDelete.status()).toBe(404);
+        await expect
+            .poll(async () => await getAttachmentStorageStats(page))
+            .toEqual({ metadataCount: 1, fileCount: 1 });
+
+        const ownerDelete = await page.request.delete(attachmentMemberUrl(ownerItemId, attachment._id), {
+            headers: { 'X-Inventory-Attachment-Request': '1' },
+        });
+        expect(ownerDelete.status()).toBe(204);
+        await expect
+            .poll(async () => await getAttachmentStorageStats(page))
+            .toEqual({ metadataCount: 0, fileCount: 0 });
+    });
+});

--- a/tests/e2e/app/import-export.spec.ts
+++ b/tests/e2e/app/import-export.spec.ts
@@ -23,6 +23,9 @@ test.describe('Import/Export Data', () => {
         // 2. Navigate to /settings/data
         await page.goto('/settings/data');
         await expect(page.getByRole('heading', { name: 'Export Data' })).toBeVisible();
+        const attachmentDisclosure = page.getByRole('note', { name: 'Attachment export limitation' });
+        await expect(attachmentDisclosure).toContainText('JSON and CSV exports do not include attachment files.');
+        await expect(attachmentDisclosure).toContainText('but not attachments.');
 
         // 3. Click "Download JSON" and capture download
         const downloadPromise = page.waitForEvent('download');

--- a/tests/e2e/helpers/database.ts
+++ b/tests/e2e/helpers/database.ts
@@ -5,6 +5,11 @@
 
 import type { Page } from '@playwright/test';
 
+export interface AttachmentStorageStats {
+    metadataCount: number;
+    fileCount: number;
+}
+
 /**
  * Reset the entire database (remove all items, tags, and attachments).
  * This ensures each test starts with a clean slate.
@@ -21,6 +26,18 @@ export async function resetDatabase(page: Page): Promise<void> {
         const body = await response.text();
         throw new Error(`Failed to reset database: ${response.status()} ${body}`);
     }
+}
+
+/** Read attachment metadata and GridFS file counts from the guarded E2E endpoint. */
+export async function getAttachmentStorageStats(page: Page): Promise<AttachmentStorageStats> {
+    const response = await page.request.get('/api/test/attachment-storage');
+
+    if (!response.ok()) {
+        const body = await response.text();
+        throw new Error(`Failed to read attachment storage: ${response.status()} ${body}`);
+    }
+
+    return (await response.json()) as AttachmentStorageStats;
 }
 
 /**

--- a/tests/e2e/storybook/AttachmentPanel.spec.ts
+++ b/tests/e2e/storybook/AttachmentPanel.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '@playwright/test';
+
+import { gotoStory } from '../helpers/storybook-helpers';
+
+test.describe('AttachmentPanel (Storybook)', () => {
+    test('shows the empty and failed-preview states', async ({ page }) => {
+        await gotoStory(page, 'ui-attachmentpanel', 'empty');
+        await expect(page.getByText('No attachments yet.')).toBeVisible();
+
+        await gotoStory(page, 'ui-attachmentpanel', 'missing-thumbnail');
+        await expect(page.getByText('Preview unavailable')).toBeVisible();
+    });
+
+    test('uploads and deletes through the confirmation flow', async ({ page }) => {
+        await gotoStory(page, 'ui-attachmentpanel', 'interactive');
+        await expect(page.getByTestId('attachment-story-count')).toHaveText('1');
+
+        await page.getByTestId('attachment-file-input').setInputFiles({
+            name: 'warranty.pdf',
+            mimeType: 'application/pdf',
+            buffer: Buffer.from('%PDF-1.7\n%%EOF'),
+        });
+        await page.getByRole('button', { name: 'Upload attachment' }).click();
+
+        await expect(page.getByTestId('attachment-story-count')).toHaveText('2');
+        await expect(page.getByTestId('attachment-story-action')).toHaveText('Uploaded warranty.pdf');
+
+        const uploadedRow = page.getByTestId('attachment-row').filter({ hasText: 'warranty.pdf' });
+        await uploadedRow.getByRole('button', { name: 'Delete' }).click();
+        await uploadedRow.getByRole('button', { name: 'Delete attachment' }).click();
+
+        await expect(page.getByTestId('attachment-story-count')).toHaveText('1');
+        await expect(page.getByTestId('attachment-story-action')).toHaveText('Deleted warranty.pdf');
+    });
+
+    test('rejects files larger than 20 MiB before upload', async ({ page }) => {
+        await gotoStory(page, 'ui-attachmentpanel', 'interactive');
+
+        await page.getByTestId('attachment-file-input').setInputFiles({
+            name: 'too-large.png',
+            mimeType: 'image/png',
+            buffer: Buffer.alloc(20 * 1024 * 1024 + 1),
+        });
+
+        await expect(page.getByTestId('attachment-selection-error')).toHaveText(
+            'Choose a file that is 20 MiB or smaller.'
+        );
+        await expect(page.getByRole('button', { name: 'Upload attachment' })).toBeDisabled();
+        await expect(page.getByTestId('attachment-story-count')).toHaveText('1');
+    });
+});

--- a/tests/e2e/storybook/SettingsDataView.spec.ts
+++ b/tests/e2e/storybook/SettingsDataView.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@playwright/test';
+
+import { gotoStory } from '../helpers/storybook-helpers';
+
+test.describe('SettingsDataViewPresentation (Storybook)', () => {
+    test('discloses that data exports do not contain attachment files', async ({ page }) => {
+        await gotoStory(page, 'ui-settingsdataviewpresentation', 'idle');
+
+        const attachmentDisclosure = page.getByRole('note', { name: 'Attachment export limitation' });
+        await expect(attachmentDisclosure).toContainText('JSON and CSV exports do not include attachment files.');
+        await expect(attachmentDisclosure).toContainText('but not attachments.');
+    });
+});


### PR DESCRIPTION
## Summary

- Add item-scoped upload, listing, download, thumbnail, and delete support for JPEG, PNG, and PDF attachments up to 20 MB.
- Validate file bytes and identifiers, harden state-changing requests, sanitize download headers, and keep MongoDB metadata and GridFS blobs consistent through partial failures and cleanup.
- Add the item-detail attachment UI with accessible loading, error, download, and confirmed-delete states.
- Correct the data export UI so JSON and CSV are not presented as backups of attachment files.
- Document the lifecycle and security contract and add unit, integration, Storybook, and app E2E coverage.

## Why

This delivers the smallest trustworthy attachment vertical slice while keeping advanced workflows—such as HEIC, batch upload, ordering, richer viewers, and complete attachment backup/restore—explicitly deferred. It is suitable for a pre-1.0 (v0.x) application release.

## User impact

Users can attach one supported image or PDF at a time to an inventory item, preview images, download files, and delete attachments. Existing JSON and CSV import/export behavior remains data-only and now states that limitation clearly.

## Validation

- `npm run check:ci`
- Meteor unit/integration suite: 235 passed
- Storybook browser suite: 34 passed, 3 intentional skips
- Full app browser matrix: 237 passed, 3 intentional skips
- Focused attachment lifecycle: Chromium and iPhone WebKit passed
- Storage assertions verified deletion and reset leave zero attachment metadata and zero GridFS files
- Forged and oversized inputs allocated no storage
- Production dependency audit found no high or critical vulnerabilities; the existing moderate nested `qs` exception remains documented
- `git diff --check`
