### PR TITLE
feat(docker): make Mongo explorer opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ E2E tests treat local Meteor Mongo as disposable and may reset it. The test rese
 
 The Docker stack includes Mongo Express as an opt-in, read-only data explorer. Normal Compose startup leaves it stopped, and MongoDB is reachable only by other containers on the Compose network. The deprecated upstream image is pinned to a tested version and must remain private.
 
-Before generating `.env`, add `mongo-express-browser-password` and `mongo-express-database-password` password fields to the 1Password item referenced by `env.tpl`. The browser password protects the web UI; the database password belongs to a separate MongoDB user that can only read `inventory-app`. Generate both passwords with letters and digits only; the database password is embedded in a MongoDB connection URL, and this avoids URL or `.env` escaping problems.
+Before generating `.env`, add `mongo-express-browser-password` and `mongo-express-database-password` password fields to the 1Password item referenced by `env.tpl`. The browser password protects the web UI; the database password belongs to a separate MongoDB user that can only read `inventory-app`. Generate both passwords with letters and digits only to avoid `.env` escaping problems.
 
 Start the explorer and its MongoDB dependency:
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,30 @@ npm run start:personal
 
 E2E tests treat local Meteor Mongo as disposable and may reset it. The test reset endpoint only runs when Playwright starts Meteor with `E2E_RESET_DATABASE=1` and refuses non-test Mongo URLs.
 
+### Docker Mongo Explorer
+
+The Docker stack includes Mongo Express as an opt-in, read-only data explorer. Normal Compose startup leaves it stopped, and MongoDB is reachable only by other containers on the Compose network.
+
+Start the explorer and its MongoDB dependency:
+
+```bash
+docker compose --profile admin up -d mongo-express
+```
+
+Stop the explorer when finished:
+
+```bash
+docker compose stop mongo-express
+```
+
+The explorer binds to `127.0.0.1:${MONGO_ADMIN_PORT}` by default and uses the configured Mongo credentials for browser authentication. From another computer, use an SSH tunnel and then open `http://localhost:8081`:
+
+```bash
+ssh -N -L 8081:127.0.0.1:<configured-admin-port> <home-server>
+```
+
+Set `MONGO_ADMIN_BIND_IP` only when the explorer should listen on a specific trusted private interface, such as the server's Tailscale address. Set `MONGO_EXPRESS_READONLY=false` for a session that requires data changes.
+
 ## Features
 
 ### Design System

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ E2E tests treat local Meteor Mongo as disposable and may reset it. The test rese
 
 ### Docker Mongo Explorer
 
-The Docker stack includes Mongo Express as an opt-in, read-only data explorer. Normal Compose startup leaves it stopped, and MongoDB is reachable only by other containers on the Compose network.
+The Docker stack includes Mongo Express as an opt-in, read-only data explorer. Normal Compose startup leaves it stopped, and MongoDB is reachable only by other containers on the Compose network. The deprecated upstream image is pinned to a tested version and must remain private.
+
+Before generating `.env`, add `mongo-express-browser-password` and `mongo-express-database-password` password fields to the 1Password item referenced by `env.tpl`. The browser password protects the web UI; the database password belongs to a separate MongoDB user that can only read `inventory-app`. Generate both passwords with letters and digits only; the database password is embedded in a MongoDB connection URL, and this avoids URL or `.env` escaping problems.
 
 Start the explorer and its MongoDB dependency:
 
@@ -43,13 +45,13 @@ Stop the explorer when finished:
 docker compose stop mongo-express
 ```
 
-The explorer binds to `127.0.0.1:${MONGO_ADMIN_PORT}` by default and uses the configured Mongo credentials for browser authentication. From another computer, use an SSH tunnel and then open `http://localhost:8081`:
+The explorer binds to `127.0.0.1:${MONGO_ADMIN_PORT}` by default. Sign in with `MONGO_EXPRESS_USERNAME` and `MONGO_EXPRESS_PASSWORD`. From another computer, use an SSH tunnel and then open `http://localhost:8081`:
 
 ```bash
 ssh -N -L 8081:127.0.0.1:<configured-admin-port> <home-server>
 ```
 
-Set `MONGO_ADMIN_BIND_IP` only when the explorer should listen on a specific trusted private interface, such as the server's Tailscale address. Set `MONGO_EXPRESS_READONLY=false` for a session that requires data changes.
+Set `MONGO_ADMIN_BIND_IP` only when the explorer should listen on a specific trusted private interface, such as the server's Tailscale address. Mongo Express hides editing controls and connects as a database user with only the `read` role; use another deliberately privileged tool for data changes.
 
 ## Features
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+version: '3.8'
+
 services:
     meteorapp:
         build:
@@ -21,25 +23,66 @@ services:
             MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD}
         command:
             - --storageEngine=wiredTiger
+        healthcheck:
+            test:
+                - CMD-SHELL
+                - 'mongo --quiet --username "$$MONGO_INITDB_ROOT_USERNAME" --password "$$MONGO_INITDB_ROOT_PASSWORD" --authenticationDatabase admin --eval "quit(db.runCommand({ ping: 1 }).ok ? 0 : 2)"'
+            interval: 5s
+            timeout: 5s
+            retries: 24
+            start_period: 10s
 
-    mongo-express:
-        image: mongo-express:latest
+    mongo-express-user:
+        image: mongo:4
         profiles: ['admin']
         restart: 'no'
         environment:
-            ME_CONFIG_MONGODB_ADMINUSERNAME: ${MONGO_USERNAME}
-            ME_CONFIG_MONGODB_ADMINPASSWORD: ${MONGO_PASSWORD}
-            ME_CONFIG_MONGODB_ENABLE_ADMIN: 'true'
-            ME_CONFIG_MONGODB_PORT: 27017
-            ME_CONFIG_MONGODB_SERVER: mongodb
-            ME_CONFIG_BASICAUTH_ENABLED: 'true'
-            ME_CONFIG_BASICAUTH_USERNAME: ${MONGO_USERNAME}
-            ME_CONFIG_BASICAUTH_PASSWORD: ${MONGO_PASSWORD}
-            ME_CONFIG_OPTIONS_READONLY: '${MONGO_EXPRESS_READONLY:-true}'
+            MONGO_EXPRESS_DB_USERNAME: '${MONGO_EXPRESS_DB_USERNAME:-}'
+            MONGO_EXPRESS_DB_PASSWORD: '${MONGO_EXPRESS_DB_PASSWORD:-}'
+        volumes:
+            - ./docker/mongo/create-explorer-user.js:/scripts/create-explorer-user.js:ro
+        entrypoint:
+            - mongo
+            - --host
+            - mongodb
+            - --quiet
+            - --username
+            - ${MONGO_USERNAME}
+            - --password
+            - ${MONGO_PASSWORD}
+            - --authenticationDatabase
+            - admin
+            - /scripts/create-explorer-user.js
+        depends_on:
+            mongodb:
+                condition: service_healthy
+
+    mongo-express:
+        image: mongo-express:1.0.2-20-alpine3.19
+        profiles: ['admin']
+        restart: 'no'
+        volumes:
+            - ./docker/mongo-express-entrypoint.sh:/scripts/mongo-express-entrypoint.sh:ro
+        entrypoint:
+            - /sbin/tini
+            - --
+            - /bin/sh
+            - /scripts/mongo-express-entrypoint.sh
+        environment:
+            ME_CONFIG_MONGODB_URL: mongodb://${MONGO_EXPRESS_DB_USERNAME:-}:${MONGO_EXPRESS_DB_PASSWORD:-}@mongodb:27017/inventory-app
+            ME_CONFIG_MONGODB_ENABLE_ADMIN: 'false'
+            ME_CONFIG_BASICAUTH: 'true'
+            ME_CONFIG_BASICAUTH_USERNAME: '${MONGO_EXPRESS_USERNAME:-}'
+            ME_CONFIG_BASICAUTH_PASSWORD: '${MONGO_EXPRESS_PASSWORD:-}'
+            ME_CONFIG_OPTIONS_READONLY: 'true'
+            ME_CONFIG_OPTIONS_NO_DELETE: 'true'
         ports:
             - '${MONGO_ADMIN_BIND_IP:-127.0.0.1}:${MONGO_ADMIN_PORT}:8081'
         depends_on:
-            - mongodb
+            mongodb:
+                condition: service_healthy
+            mongo-express-user:
+                condition: service_completed_successfully
 
 volumes:
     inventory_app_mongodb_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
     meteorapp:
         build:
@@ -21,22 +19,25 @@ services:
         environment:
             MONGO_INITDB_ROOT_USERNAME: ${MONGO_USERNAME}
             MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD}
-        ports:
-            - '27017:27017'
         command:
             - --storageEngine=wiredTiger
 
     mongo-express:
         image: mongo-express:latest
-        restart: always
+        profiles: ['admin']
+        restart: 'no'
         environment:
             ME_CONFIG_MONGODB_ADMINUSERNAME: ${MONGO_USERNAME}
             ME_CONFIG_MONGODB_ADMINPASSWORD: ${MONGO_PASSWORD}
-            ME_CONFIG_MONGODB_ENABLE_ADMIN: true
+            ME_CONFIG_MONGODB_ENABLE_ADMIN: 'true'
             ME_CONFIG_MONGODB_PORT: 27017
             ME_CONFIG_MONGODB_SERVER: mongodb
+            ME_CONFIG_BASICAUTH_ENABLED: 'true'
+            ME_CONFIG_BASICAUTH_USERNAME: ${MONGO_USERNAME}
+            ME_CONFIG_BASICAUTH_PASSWORD: ${MONGO_PASSWORD}
+            ME_CONFIG_OPTIONS_READONLY: '${MONGO_EXPRESS_READONLY:-true}'
         ports:
-            - '${MONGO_ADMIN_PORT}:8081'
+            - '${MONGO_ADMIN_BIND_IP:-127.0.0.1}:${MONGO_ADMIN_PORT}:8081'
         depends_on:
             - mongodb
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,10 @@ services:
             MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD}
         command:
             - --storageEngine=wiredTiger
+        networks:
+            default:
+                aliases:
+                    - mongo
         healthcheck:
             test:
                 - CMD-SHELL
@@ -69,8 +73,12 @@ services:
             - /bin/sh
             - /scripts/mongo-express-entrypoint.sh
         environment:
-            ME_CONFIG_MONGODB_URL: mongodb://${MONGO_EXPRESS_DB_USERNAME:-}:${MONGO_EXPRESS_DB_PASSWORD:-}@mongodb:27017/inventory-app
+            ME_CONFIG_MONGODB_AUTH_DATABASE: inventory-app
+            ME_CONFIG_MONGODB_AUTH_PASSWORD: '${MONGO_EXPRESS_DB_PASSWORD:-}'
+            ME_CONFIG_MONGODB_AUTH_USERNAME: '${MONGO_EXPRESS_DB_USERNAME:-}'
             ME_CONFIG_MONGODB_ENABLE_ADMIN: 'false'
+            ME_CONFIG_MONGODB_PORT: '27017'
+            ME_CONFIG_MONGODB_SERVER: mongodb
             ME_CONFIG_BASICAUTH: 'true'
             ME_CONFIG_BASICAUTH_USERNAME: '${MONGO_EXPRESS_USERNAME:-}'
             ME_CONFIG_BASICAUTH_PASSWORD: '${MONGO_EXPRESS_PASSWORD:-}'

--- a/docker/mongo-express-entrypoint.sh
+++ b/docker/mongo-express-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eu
+
+if [ -z "${ME_CONFIG_BASICAUTH_USERNAME:-}" ] || [ -z "${ME_CONFIG_BASICAUTH_PASSWORD:-}" ]; then
+    echo 'Mongo Express browser username and password are required.' >&2
+    exit 1
+fi
+
+exec /docker-entrypoint.sh mongo-express

--- a/docker/mongo/create-explorer-user.js
+++ b/docker/mongo/create-explorer-user.js
@@ -1,0 +1,25 @@
+/**
+ * Reconciles the MongoDB account used by the opt-in data explorer.
+ * The one-shot Compose service runs this with root access before Mongo Express.
+ *
+ * Belongs here: creating or rotating the explorer's inventory-app-only read user.
+ * Does not belong here: application users, browser authentication, or write roles.
+ */
+
+const username = _getEnv('MONGO_EXPRESS_DB_USERNAME');
+const password = _getEnv('MONGO_EXPRESS_DB_PASSWORD');
+
+if (!username || !password) {
+    throw new Error('MONGO_EXPRESS_DB_USERNAME and MONGO_EXPRESS_DB_PASSWORD are required');
+}
+
+const inventoryDatabase = db.getSiblingDB('inventory-app');
+const roles = [{ role: 'read', db: 'inventory-app' }];
+
+if (inventoryDatabase.getUser(username)) {
+    inventoryDatabase.updateUser(username, { pwd: password, roles });
+    print('Updated the Mongo Express read-only database user.');
+} else {
+    inventoryDatabase.createUser({ user: username, pwd: password, roles });
+    print('Created the Mongo Express read-only database user.');
+}

--- a/env.tpl
+++ b/env.tpl
@@ -1,5 +1,8 @@
 MONGO_USERNAME={{ op://h6tlihxwgcjiljrwd52ifhxkki/n77bpzv66binxguygdq75jdxua/username }}
 MONGO_PASSWORD={{ op://h6tlihxwgcjiljrwd52ifhxkki/n77bpzv66binxguygdq75jdxua/password }}
 MONGO_ADMIN_PORT={{ op://h6tlihxwgcjiljrwd52ifhxkki/n77bpzv66binxguygdq75jdxua/mongo-express-port }}
+MONGO_EXPRESS_USERNAME=mongo-explorer
+MONGO_EXPRESS_PASSWORD='{{ op://h6tlihxwgcjiljrwd52ifhxkki/n77bpzv66binxguygdq75jdxua/mongo-express-browser-password }}'
+MONGO_EXPRESS_DB_USERNAME=inventory-explorer
+MONGO_EXPRESS_DB_PASSWORD='{{ op://h6tlihxwgcjiljrwd52ifhxkki/n77bpzv66binxguygdq75jdxua/mongo-express-database-password }}'
 NAS_MONGO_URL=mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@{{ op://h6tlihxwgcjiljrwd52ifhxkki/n77bpzv66binxguygdq75jdxua/mongo-host-and-port }}/inventory-app?&authSource=admin
-


### PR DESCRIPTION
## Summary

- keep MongoDB private on the Compose network instead of publishing port 27017 to the host
- make Mongo Express an opt-in `admin` profile
- bind the explorer to loopback by default, enable browser authentication, and default to read-only access
- document startup, shutdown, SSH tunneling, and trusted-interface overrides

## Why

This supports a temporary home-server MongoDB deployment with an on-demand data explorer without leaving either MongoDB or its admin UI continuously exposed.

## Validation

- `npx prettier --check docker-compose.yml README.md`
- `docker compose config --quiet` with validation-only environment values
- verified default services are `mongodb` and `meteorapp`
- verified the `admin` profile additionally enables `mongo-express`
- verified MongoDB has no published host port and Mongo Express defaults to loopback, read-only mode, and Basic authentication
