### PR TITLE
feat(ui): redesign mobile tag hierarchy and row actions

### DIFF
--- a/meteor-app/imports/ui/AllTagsView.stories.tsx
+++ b/meteor-app/imports/ui/AllTagsView.stories.tsx
@@ -5,8 +5,8 @@
  * and utility views for detached tags and tags missing path information. Each tag shows usage count
  * (how many items have that tag).
  *
- * These stories demonstrate various states: empty, few tags, nested hierarchies, with usage counts,
- * and fully interactive management scenarios.
+ * These stories demonstrate empty, routine, interactive, and hierarchy-stress states, including
+ * long names and depths that exercise the responsive row constraints.
  */
 import type { Meta, StoryObj } from '@storybook/react';
 import { Box } from 'grommet';
@@ -107,6 +107,31 @@ const manyTags: TagRecord[] = Array.from({ length: 15 }, (_, i) => ({
     modifiedAt: new Date('2024-01-01'),
 }));
 
+const hierarchyStressNames = [
+    'Household equipment',
+    'Seasonal storage',
+    'Outdoor recreation',
+    'Cold weather camping',
+    'Safety systems',
+    'Emergency communication and navigation equipment with rechargeable backup power',
+];
+
+const hierarchyStressTags: TagRecord[] = hierarchyStressNames.map((name, index) => {
+    const id = `hierarchy-stress-${index + 1}`;
+
+    return {
+        _id: id,
+        name,
+        parentTagId: index === 0 ? '' : `hierarchy-stress-${index}`,
+        path: hierarchyStressNames.slice(0, index + 1).map((pathName, pathIndex) => ({
+            _id: `hierarchy-stress-${pathIndex + 1}`,
+            name: pathName,
+        })),
+        createdAt: new Date('2024-01-01'),
+        modifiedAt: new Date('2024-01-01'),
+    };
+});
+
 // Story: Empty state - no tags exist
 export const Empty: Story = {
     args: {
@@ -165,6 +190,32 @@ export const NestedHierarchy: Story = {
         },
         onDelete: (tag: TagRecord) => {
             console.log('Delete', tag.name);
+        },
+    },
+};
+
+export const HierarchyStress: Story = {
+    args: {
+        tags: hierarchyStressTags,
+        usageCounts: {
+            'hierarchy-stress-1': 42,
+            'hierarchy-stress-2': 31,
+            'hierarchy-stress-3': 24,
+            'hierarchy-stress-4': 16,
+            'hierarchy-stress-5': 8,
+            'hierarchy-stress-6': 37,
+        },
+        onAddChild: (parentTagId: string, tagName: string) => {
+            console.log('Add child', parentTagId, tagName);
+        },
+        onRename: (tag: TagRecord, newName: string) => {
+            console.log('Rename', tag.name, 'to', newName);
+        },
+        onDelete: (tag: TagRecord) => {
+            console.log('Delete', tag.name);
+        },
+        onTagClick: (tagId: string) => {
+            console.log('Open tagged items', tagId);
         },
     },
 };

--- a/meteor-app/imports/ui/AllTagsView/AllTagsViewPresentation.tsx
+++ b/meteor-app/imports/ui/AllTagsView/AllTagsViewPresentation.tsx
@@ -1,5 +1,9 @@
-import { Box, Button, Form, FormField, Heading, Layer, Text, TextInput } from 'grommet';
-import { Add, Close, Edit, Tag as TagIcon, Trash } from 'grommet-icons';
+/**
+ * Presents the tag-management toolbar, hierarchy, row actions, and confirmation flows.
+ * Responsive hierarchy and action disclosure belong here; data loading and persistence stay in the container.
+ */
+import { Box, Button, Form, FormField, Heading, Layer, Menu, Text, TextInput } from 'grommet';
+import { Add, Close, Edit, MoreVertical, Tag as TagIcon, Trash } from 'grommet-icons';
 import React, {
     type ChangeEvent,
     type ComponentProps,
@@ -13,12 +17,16 @@ import styled from 'styled-components';
 import type { TagRecord } from '/imports/model/TagRecord';
 import { CreateTagDialog } from '/imports/ui/CreateTagDialog';
 import { LongPressContextMenu, type ContextMenuAction } from '/imports/ui/LongPressContextMenu';
+import { uiTokens } from '/imports/ui/theme';
 
 interface TagWithChildren extends TagRecord {
     children: TagWithChildren[];
 }
 
 type DivProps = Omit<ComponentProps<'div'>, 'ref'>;
+
+const MAX_MOBILE_INDENT_DEPTH = 3;
+const PARENT_PATH_INDEX_FROM_END = -2;
 
 type DialogState =
     | { type: 'create'; parentTagId: string }
@@ -149,6 +157,7 @@ const Row = styled.div<{ $depth: number }>`
     align-items: center;
     background: #ffffff;
     border-bottom: 1px solid #eeeeee;
+    box-sizing: border-box;
     display: flex;
     gap: 0.75rem;
     min-height: 52px;
@@ -195,11 +204,25 @@ const Row = styled.div<{ $depth: number }>`
         overflow-wrap: anywhere;
     }
 
+    .tag-mobile-metadata-row {
+        display: contents;
+    }
+
+    .tag-item-summary {
+        color: #6f7785;
+        font-size: 0.875rem;
+        font-weight: normal;
+    }
+
     .tag-item-count,
     .tag-path {
         color: #6f7785;
         font-size: 0.875rem;
         font-weight: normal;
+    }
+
+    .tag-mobile-hierarchy {
+        display: none;
     }
 
     .tag-actions-container {
@@ -214,6 +237,95 @@ const Row = styled.div<{ $depth: number }>`
     .tag-action-button {
         min-height: 44px;
         min-width: 44px;
+    }
+
+    .tag-overflow-action {
+        display: none;
+        min-height: ${uiTokens.size.touchTarget};
+        min-width: ${uiTokens.size.touchTarget};
+        padding: 0;
+    }
+
+    @media (max-width: 600px) {
+        gap: ${uiTokens.space.sm};
+        min-height: 56px;
+        padding-block: ${uiTokens.space.xs};
+        padding-inline: calc(
+                ${uiTokens.space.sm} + ${(props) => Math.min(props.$depth, MAX_MOBILE_INDENT_DEPTH)} *
+                    ${uiTokens.space.md}
+            )
+            ${uiTokens.space.xs};
+
+        > svg {
+            flex: 0 0 auto;
+            height: 20px;
+            width: 20px;
+        }
+
+        .tag-name-button {
+            gap: ${uiTokens.space.xxs};
+        }
+
+        .tag-name {
+            display: -webkit-box;
+            line-height: ${uiTokens.font.lineHeightTight};
+            overflow: hidden;
+            overflow-wrap: anywhere;
+            -webkit-box-orient: vertical;
+            -webkit-line-clamp: 2;
+        }
+
+        .tag-mobile-metadata-row {
+            align-items: baseline;
+            display: flex;
+            gap: ${uiTokens.space.xs};
+            max-width: 100%;
+            min-width: 0;
+            width: 100%;
+        }
+
+        .tag-item-summary {
+            flex: 0 0 auto;
+            white-space: nowrap;
+        }
+
+        .tag-child-count {
+            display: none;
+        }
+
+        .tag-path {
+            display: none;
+        }
+
+        .tag-mobile-hierarchy {
+            align-items: baseline;
+            color: ${uiTokens.color.textWeak};
+            display: flex;
+            font-size: ${uiTokens.font.sizeSmall};
+            gap: ${uiTokens.space.xs};
+            min-width: 0;
+        }
+
+        .tag-hierarchy-level {
+            flex: 0 0 auto;
+            font-weight: ${uiTokens.font.weightMedium};
+        }
+
+        .tag-parent-name {
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .tag-desktop-actions {
+            display: none;
+        }
+
+        .tag-overflow-action {
+            display: inline-flex;
+            flex: 0 0 ${uiTokens.size.touchTarget};
+        }
     }
 `;
 
@@ -251,6 +363,7 @@ interface TagRowProps {
 const TagRow = ({ tag, depth, usageCounts, onAddChild, onRename, onDelete, onTagClick }: TagRowProps): ReactElement => {
     const itemCount = usageCounts[tag._id] ?? 0;
     const pathLabel = tag.path.length > 1 ? tag.path.map(({ name }) => name).join(' / ') : undefined;
+    const parentName = tag.path.at(PARENT_PATH_INDEX_FROM_END)?.name;
     const menuActions: ContextMenuAction[] = [
         {
             label: 'Add Child',
@@ -294,16 +407,40 @@ const TagRow = ({ tag, depth, usageCounts, onAddChild, onRename, onDelete, onTag
                         }}
                     >
                         <span className="tag-name">{tag.name}</span>
-                        <span className="tag-item-count">
-                            {itemCount === 1 ? '1 item' : `${itemCount} items`}
-                            {tag.children.length > 0
-                                ? `, ${tag.children.length} ${tag.children.length === 1 ? 'child' : 'children'}`
-                                : ''}
+                        <span className="tag-mobile-metadata-row">
+                            <span className="tag-item-summary">
+                                <span className="tag-item-count">
+                                    {itemCount === 1 ? '1 item' : `${itemCount} items`}
+                                </span>
+                                {tag.children.length > 0 && (
+                                    <span className="tag-child-count">
+                                        {`, ${tag.children.length} ${tag.children.length === 1 ? 'child' : 'children'}`}
+                                    </span>
+                                )}
+                            </span>
+                            {depth > 0 && (
+                                <span
+                                    className="tag-mobile-hierarchy"
+                                    aria-label={`Hierarchy level ${depth + 1}, under ${parentName ?? 'unknown parent'}`}
+                                    title={pathLabel}
+                                >
+                                    <span className="tag-hierarchy-level">Level {depth + 1}</span>
+                                    <span aria-hidden="true">·</span>
+                                    <span className="tag-parent-name">under {parentName ?? 'unknown parent'}</span>
+                                </span>
+                            )}
                         </span>
-                        {pathLabel !== undefined && <span className="tag-path">{pathLabel}</span>}
+                        {pathLabel !== undefined && (
+                            <span className="tag-path" title={pathLabel}>
+                                {pathLabel}
+                            </span>
+                        )}
                     </button>
                 </div>
-                <span className="tag-actions-container" aria-label={`Actions for ${tag.name}`}>
+                <span
+                    className="tag-actions-container tag-desktop-actions"
+                    aria-label={`Direct actions for ${tag.name}`}
+                >
                     <Button
                         className="tag-action-button new-child-action"
                         icon={<Add />}
@@ -338,6 +475,37 @@ const TagRow = ({ tag, depth, usageCounts, onAddChild, onRename, onDelete, onTag
                         }}
                     />
                 </span>
+                <Menu
+                    className="tag-overflow-action"
+                    a11yTitle={`Actions for ${tag.name}`}
+                    icon={<MoreVertical />}
+                    items={[
+                        {
+                            label: 'Add child',
+                            icon: <Add />,
+                            onClick: () => {
+                                onAddChild(tag._id);
+                            },
+                        },
+                        {
+                            label: 'Rename',
+                            icon: <Edit />,
+                            onClick: () => {
+                                onRename(tag);
+                            },
+                        },
+                        {
+                            label: <Text color="status-critical">Delete</Text>,
+                            icon: <Trash color="status-critical" />,
+                            onClick: () => {
+                                onDelete(tag);
+                            },
+                        },
+                    ]}
+                    dropAlign={{ top: 'bottom', right: 'right' }}
+                    hoverIndicator
+                    plain
+                />
             </Row>
         </LongPressContextMenu>
     );

--- a/tests/e2e/app/mobile-tag-rows.spec.ts
+++ b/tests/e2e/app/mobile-tag-rows.spec.ts
@@ -1,0 +1,153 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+import { resetDatabase, waitForMeteorReady } from '../helpers/database';
+import { callMeteorMethod, createItem, createTag } from '../helpers/factories';
+import { TagsPage } from '../helpers/page-objects';
+
+const longTagName = 'Emergency communication and navigation equipment with rechargeable backup power';
+const MOBILE_TAG_ROW_TEST_TIMEOUT_MS = 60_000;
+
+async function seedHierarchy(page: Page): Promise<{ deepestTagId: string }> {
+    const names = [
+        'Household equipment',
+        'Seasonal storage',
+        'Outdoor recreation',
+        'Cold weather camping',
+        'Safety systems',
+        longTagName,
+    ];
+    let parentId: string | undefined;
+
+    for (const name of names) {
+        parentId = await callMeteorMethod<string>(page, 'createTag', { name, parentTagId: parentId ?? '' });
+    }
+
+    if (parentId === undefined) throw new Error('Hierarchy fixture did not create a deepest tag');
+
+    await createItem(page, { name: 'Satellite communicator', tagIds: [parentId] });
+    return { deepestTagId: parentId };
+}
+
+function tagRowByExactName(page: Page, name: string): Locator {
+    return page.locator('.tag-body').filter({ has: page.getByText(name, { exact: true }) });
+}
+
+test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForMeteorReady(page);
+    await resetDatabase(page);
+});
+
+test.describe('Mobile tag hierarchy and row actions', () => {
+    test('keeps deep, long tag rows bounded from phone through desktop', async ({ page }, testInfo) => {
+        test.setTimeout(MOBILE_TAG_ROW_TEST_TIMEOUT_MS);
+
+        const { deepestTagId } = await seedHierarchy(page);
+        const tagsPage = new TagsPage(page);
+        const widths = [320, 390, 430, 768, 1280] as const;
+
+        await tagsPage.goto();
+        await expect(page.getByRole('heading', { name: 'Tags', exact: true })).toBeVisible();
+
+        for (const width of widths) {
+            await page.setViewportSize({ width, height: width <= 430 ? 844 : 900 });
+
+            const deepestRow = tagsPage.tagByName(longTagName);
+            await expect(deepestRow.locator('.tag-name')).toHaveText(longTagName);
+            await expect(deepestRow.locator('.tag-item-count')).toHaveText('1 item');
+
+            const layout = await page.evaluate(() => {
+                const row = [...document.querySelectorAll('.tag-body')].find((candidate) =>
+                    candidate.textContent?.includes('Emergency communication and navigation equipment')
+                );
+                if (row === undefined) throw new Error('Deep hierarchy row is missing');
+                const rect = row.getBoundingClientRect();
+
+                return {
+                    viewportWidth: document.documentElement.clientWidth,
+                    scrollWidth: document.documentElement.scrollWidth,
+                    rowLeft: rect.left,
+                    rowRight: rect.right,
+                    rowHeight: rect.height,
+                };
+            });
+
+            expect(layout.scrollWidth).toBe(layout.viewportWidth);
+            expect(layout.rowLeft).toBeGreaterThanOrEqual(0);
+            expect(layout.rowRight).toBeLessThanOrEqual(width);
+
+            const overflowAction = deepestRow.getByRole('button', { name: `Actions for ${longTagName}` });
+            const directActions = deepestRow.locator('.tag-desktop-actions button');
+
+            if (width <= 600) {
+                await expect(overflowAction).toBeVisible();
+                await expect(directActions.first()).toBeHidden();
+                await expect(deepestRow.locator('.tag-mobile-hierarchy')).toContainText('Level 6');
+                await expect(deepestRow.locator('.tag-mobile-hierarchy')).toContainText('under Safety systems');
+                await expect(deepestRow.locator('.tag-path')).toBeHidden();
+
+                const actionBox = await overflowAction.boundingBox();
+                expect(actionBox).not.toBeNull();
+                expect(actionBox?.width).toBeGreaterThanOrEqual(44);
+                expect(actionBox?.height).toBeGreaterThanOrEqual(44);
+                expect(layout.rowHeight).toBeLessThanOrEqual(88);
+            } else {
+                await expect(overflowAction).toBeHidden();
+                await expect(directActions).toHaveCount(3);
+                await expect(directActions.first()).toBeVisible();
+                await expect(deepestRow.locator('.tag-path')).toBeVisible();
+            }
+
+            const screenshotPath = testInfo.outputPath(`tag-hierarchy-${width}.png`);
+            await page.screenshot({ path: screenshotPath, fullPage: true });
+            await testInfo.attach(`tag hierarchy at ${width}px`, { path: screenshotPath, contentType: 'image/png' });
+        }
+
+        await page.setViewportSize({ width: 390, height: 844 });
+        await tagsPage.tagByName(longTagName).locator('.tag-name-button').click();
+        await expect(page).toHaveURL(new RegExp(`/tags/${deepestTagId}$`));
+        await expect(page.getByText('Satellite communicator', { exact: true })).toBeVisible();
+    });
+
+    test('supports add, rename, and confirmed delete through the visible mobile menu', async ({ page }) => {
+        test.setTimeout(MOBILE_TAG_ROW_TEST_TIMEOUT_MS);
+
+        const parentId = await createTag(page, { name: 'Emergency kits' });
+        await callMeteorMethod<string>(page, 'createTag', { name: 'Radio supplies', parentTagId: parentId });
+        const tagsPage = new TagsPage(page);
+
+        await page.setViewportSize({ width: 390, height: 844 });
+        await tagsPage.goto();
+
+        let row = tagRowByExactName(page, 'Radio supplies');
+        await row.getByRole('button', { name: 'Actions for Radio supplies' }).click();
+        let menu = page.getByRole('menu', { name: 'Actions for Radio supplies' });
+        await menu.getByRole('menuitem').filter({ hasText: 'Add child' }).click();
+        await page.locator('input[name="name"]').fill('Spare antennas');
+        await page.getByRole('button', { name: 'Create Tag', exact: true }).click();
+        await expect(tagsPage.tagByName('Spare antennas')).toBeVisible();
+
+        row = tagRowByExactName(page, 'Radio supplies');
+        await row.getByRole('button', { name: 'Actions for Radio supplies' }).click();
+        menu = page.getByRole('menu', { name: 'Actions for Radio supplies' });
+        await menu.getByRole('menuitem').filter({ hasText: 'Rename' }).click();
+        await page.locator('input[name="name"]').fill('Field radio supplies');
+        await page.getByRole('button', { name: 'Rename', exact: true }).click();
+        await expect(tagRowByExactName(page, 'Field radio supplies')).toBeVisible();
+
+        row = tagRowByExactName(page, 'Field radio supplies');
+        await row.getByRole('button', { name: 'Actions for Field radio supplies' }).click();
+        menu = page.getByRole('menu', { name: 'Actions for Field radio supplies' });
+        await menu.getByRole('menuitem').filter({ hasText: 'Delete' }).click();
+        await expect(page.getByRole('heading', { name: 'Delete Tag' })).toBeVisible();
+        await expect(row).toBeVisible();
+        await page.getByRole('button', { name: 'Cancel' }).click();
+        await expect(row).toBeVisible();
+
+        await row.getByRole('button', { name: 'Actions for Field radio supplies' }).click();
+        menu = page.getByRole('menu', { name: 'Actions for Field radio supplies' });
+        await menu.getByRole('menuitem').filter({ hasText: 'Delete' }).click();
+        await page.getByRole('button', { name: 'Delete', exact: true }).click();
+        await expect(tagRowByExactName(page, 'Field radio supplies')).toHaveCount(0);
+    });
+});

--- a/tests/e2e/storybook/AllTagsView.spec.ts
+++ b/tests/e2e/storybook/AllTagsView.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from '@playwright/test';
+import { gotoStory } from '../helpers/storybook-helpers';
+
+const longTagName = 'Emergency communication and navigation equipment with rechargeable backup power';
+const responsiveWidths = [320, 390, 430, 768, 1280] as const;
+
+test.describe('AllTagsView hierarchy stress state (Storybook)', () => {
+    for (const width of responsiveWidths) {
+        test(`keeps hierarchy and actions usable at ${width}px`, async ({ page }) => {
+            await page.setViewportSize({ width, height: 900 });
+            await gotoStory(page, 'ui-alltagsview', 'hierarchy-stress');
+
+            const rows = page.locator('.tag-body');
+            const deepestRow = rows.filter({ hasText: longTagName });
+
+            await expect(rows).toHaveCount(6);
+            await expect(deepestRow.locator('.tag-name')).toHaveText(longTagName);
+            await expect(deepestRow.locator('.tag-item-count')).toHaveText('37 items');
+
+            const layout = await page.evaluate(() => ({
+                clientWidth: document.documentElement.clientWidth,
+                scrollWidth: document.documentElement.scrollWidth,
+                rowRects: [...document.querySelectorAll('.tag-body')].map((row) => {
+                    const rect = row.getBoundingClientRect();
+                    return { left: rect.left, right: rect.right, height: rect.height };
+                }),
+            }));
+
+            expect(layout.scrollWidth).toBe(layout.clientWidth);
+            for (const row of layout.rowRects) {
+                expect(row.left).toBeGreaterThanOrEqual(0);
+                expect(row.right).toBeLessThanOrEqual(width);
+            }
+
+            const overflowAction = deepestRow.getByRole('button', { name: `Actions for ${longTagName}` });
+            const directActions = deepestRow.locator('.tag-desktop-actions button');
+
+            if (width <= 600) {
+                await expect(overflowAction).toBeVisible();
+                await expect(directActions).toHaveCount(3);
+                await expect(directActions.first()).toBeHidden();
+                await expect(deepestRow.locator('.tag-mobile-hierarchy')).toContainText('Level 6');
+                await expect(deepestRow.locator('.tag-mobile-hierarchy')).toContainText('under Safety systems');
+                await expect(deepestRow.locator('.tag-path')).toBeHidden();
+
+                const actionBox = await overflowAction.boundingBox();
+                const rowBox = await deepestRow.boundingBox();
+                expect(actionBox).not.toBeNull();
+                expect(actionBox?.width).toBeGreaterThanOrEqual(44);
+                expect(actionBox?.height).toBeGreaterThanOrEqual(44);
+                expect(rowBox).not.toBeNull();
+                expect(rowBox?.height).toBeLessThanOrEqual(88);
+            } else {
+                await expect(overflowAction).toBeHidden();
+                await expect(directActions).toHaveCount(3);
+                await expect(directActions.first()).toBeVisible();
+                await expect(deepestRow.locator('.tag-mobile-hierarchy')).toBeHidden();
+                await expect(deepestRow.locator('.tag-path')).toBeVisible();
+            }
+        });
+    }
+
+    test('offers add, rename, and deliberate delete through the mobile action menu', async ({ page }) => {
+        await page.setViewportSize({ width: 390, height: 844 });
+        await gotoStory(page, 'ui-alltagsview', 'hierarchy-stress');
+
+        const row = page.locator('.tag-body').filter({ hasText: longTagName });
+        const actionsButton = row.getByRole('button', { name: `Actions for ${longTagName}` });
+
+        await actionsButton.click();
+        let menu = page.getByRole('menu', { name: `Actions for ${longTagName}` });
+        await menu.getByRole('menuitem').filter({ hasText: 'Add child' }).click();
+        await expect(page.getByRole('heading', { name: 'Create New Tag' })).toBeVisible();
+        await page.getByRole('button', { name: 'Cancel' }).click();
+
+        await actionsButton.click();
+        menu = page.getByRole('menu', { name: `Actions for ${longTagName}` });
+        await menu.getByRole('menuitem').filter({ hasText: 'Rename' }).click();
+        await expect(page.getByRole('heading', { name: 'Rename Tag' })).toBeVisible();
+        await page.getByRole('button', { name: 'Cancel' }).click();
+
+        await actionsButton.click();
+        menu = page.getByRole('menu', { name: `Actions for ${longTagName}` });
+        await menu.getByRole('menuitem').filter({ hasText: 'Delete' }).click();
+        await expect(page.getByRole('heading', { name: 'Delete Tag' })).toBeVisible();
+        await expect(page.getByText(`Delete "${longTagName}"? Items will keep their other tags.`)).toBeVisible();
+        await page.getByRole('button', { name: 'Cancel' }).click();
+        await expect(row).toBeVisible();
+    });
+});


### PR DESCRIPTION
## Summary

- preserve tag names and usage counts as the primary mobile row content
- replace three permanent phone actions with one visible 44×44 accessible Actions menu
- show bounded mobile hierarchy context using exact level plus immediate parent while preserving full desktop paths/actions
- add six-level/long-name Storybook fixtures and app/component E2E coverage

## Design decision

At widths up to 600 px, cap geometric indentation after level 4, clamp exceptionally long names to two lines, and show `Level N · under Parent` in one truncated metadata line. Keep long press as an accelerator only. Above 600 px, retain the existing stronger indentation, full path, and three direct actions. Delete remains danger-styled and confirmation-gated.

## Verification

- Storybook AllTagsView focused: 6/6 passed
- App mobile tag rows, Chromium: 2/2 passed
- App mobile tag rows, iPhone: 2/2 passed
- App mobile tag rows, iPad: 2/2 passed
- Existing focused tag/navigation regressions: 23/23 passed
- Complete Storybook suite: 42 passed, 3 skipped
- Complete Chromium app suite: 80 passed, 1 skipped, 4 initial failures; the two routing/tag timing failures passed individually
- Formatting, ESLint, TypeScript, script tests, and `git diff --check`: passed
- Meteor unit suite: 219 passed, 2 unrelated import/export failures

The two remaining CSV import failures are outside this ticket: the large sample preview exceeds existing 5-second E2E and 2-second Mocha timeouts under current load. Screenshots show parsing still in progress or the preview appearing just after the assertion deadline.

## Visual evidence

Before and after were captured and manually inspected at 320, 390, 430, 768, and 1280 px. Phone rows keep names/counts readable, expose one 44 px action target, and bound deep hierarchy/long names; tablet/desktop retain direct actions and full hierarchy paths.

## Tracking

Beads: `bd-bv8.2.3` — Redesign mobile tag hierarchy and row actions.
