### PR TITLE
feat(ui): redesign inventory browsing for efficient scanning

### DIFF
--- a/meteor-app/imports/ui/AllItemsView.stories.tsx
+++ b/meteor-app/imports/ui/AllItemsView.stories.tsx
@@ -4,6 +4,7 @@ import { Add, Apps, Filter, Search as SearchIcon, Tag as TagIcon } from 'grommet
 import React, { useState } from 'react';
 
 import type { InventoryItem } from '/imports/model/InventoryItem';
+import type { TagRecord } from '/imports/model/TagRecord';
 import { AllItemsViewPresentation } from '/imports/ui/AllItemsView/AllItemsViewPresentation';
 
 const meta: Meta<typeof AllItemsViewPresentation> = {
@@ -28,6 +29,33 @@ const meta: Meta<typeof AllItemsViewPresentation> = {
 export default meta;
 type Story = StoryObj<typeof AllItemsViewPresentation>;
 
+const storyTags: TagRecord[] = [
+    {
+        _id: 'storage-tag',
+        name: 'Storage',
+        parentTagId: '',
+        path: [{ _id: 'storage-tag', name: 'Storage' }],
+        createdAt: new Date('2024-01-01'),
+        modifiedAt: new Date('2024-01-01'),
+    },
+    {
+        _id: 'tools-tag',
+        name: 'Tools',
+        parentTagId: '',
+        path: [{ _id: 'tools-tag', name: 'Tools' }],
+        createdAt: new Date('2024-01-01'),
+        modifiedAt: new Date('2024-01-01'),
+    },
+    {
+        _id: 'outdoor-tag',
+        name: 'Outdoor',
+        parentTagId: '',
+        path: [{ _id: 'outdoor-tag', name: 'Outdoor' }],
+        createdAt: new Date('2024-01-01'),
+        modifiedAt: new Date('2024-01-01'),
+    },
+];
+
 // Sample data hierarchy
 const home: InventoryItem = {
     _id: 'home',
@@ -46,7 +74,7 @@ const garage: InventoryItem = {
     description: 'Two-car garage with storage',
     isContainer: true,
     containerId: 'home',
-    tagIds: [],
+    tagIds: ['storage-tag'],
     createdAt: new Date('2024-01-02'),
     modifiedAt: new Date('2024-01-02'),
 };
@@ -68,7 +96,7 @@ const toolBox: InventoryItem = {
     description: 'Red metal tool box',
     isContainer: true,
     containerId: 'garage',
-    tagIds: [],
+    tagIds: ['storage-tag', 'tools-tag'],
     createdAt: new Date('2024-01-04'),
     modifiedAt: new Date('2024-01-04'),
 };
@@ -79,7 +107,7 @@ const hammer: InventoryItem = {
     description: 'Claw hammer, 16oz',
     isContainer: false,
     containerId: 'toolbox',
-    tagIds: [],
+    tagIds: ['tools-tag'],
     createdAt: new Date('2024-01-05'),
     modifiedAt: new Date('2024-01-05'),
 };
@@ -90,7 +118,7 @@ const screwdriver: InventoryItem = {
     description: 'Phillips and flathead, 6 pieces',
     isContainer: false,
     containerId: 'toolbox',
-    tagIds: [],
+    tagIds: ['tools-tag'],
     createdAt: new Date('2024-01-06'),
     modifiedAt: new Date('2024-01-06'),
 };
@@ -101,7 +129,7 @@ const bike: InventoryItem = {
     description: '21-speed mountain bike, blue',
     isContainer: false,
     containerId: 'garage',
-    tagIds: [],
+    tagIds: ['outdoor-tag'],
     createdAt: new Date('2024-01-07'),
     modifiedAt: new Date('2024-01-07'),
 };
@@ -116,6 +144,84 @@ const scrollRegressionItems: InventoryItem[] = [
         containerId: undefined,
     })),
 ];
+
+const hundredPlusItems: InventoryItem[] = [
+    { ...garage, containerId: undefined },
+    { ...kitchen, containerId: undefined },
+    ...Array.from({ length: 104 }, (_, index) => {
+        const itemNumber = index + 1;
+        return {
+            ...hammer,
+            _id: `high-volume-item-${itemNumber}`,
+            name:
+                itemNumber === 1
+                    ? 'A deliberately long inventory item name that must truncate predictably in every responsive density mode'
+                    : `Inventory item ${itemNumber}`,
+            description:
+                itemNumber % 3 === 0 ? `Useful comparison description for inventory item ${itemNumber}` : undefined,
+            containerId: undefined,
+            tagIds: itemNumber % 5 === 0 ? ['tools-tag', 'outdoor-tag'] : itemNumber % 2 === 0 ? ['storage-tag'] : [],
+            modifiedAt: new Date(Date.UTC(2026, 0, (itemNumber % 28) + 1)),
+        };
+    }),
+];
+
+const commonStoryArgs = {
+    containerPath: [],
+    availableTags: storyTags,
+    showHomeIcon: true,
+    onNavigateToContainer: () => {
+        console.log('Navigate to container');
+    },
+    onBreadcrumbNavigate: () => {
+        console.log('Breadcrumb navigate');
+    },
+};
+
+/**
+ * Loading fixture keeps list context visible while data arrives.
+ */
+export const LoadingInventory: Story = {
+    args: {
+        ...commonStoryArgs,
+        items: [],
+        loading: true,
+    },
+};
+
+/**
+ * Empty fixture includes the zero count and empty guidance.
+ */
+export const EmptyInventory: Story = {
+    args: {
+        ...commonStoryArgs,
+        items: [],
+    },
+};
+
+/**
+ * Short fixture exercises mixed row metadata without scrolling.
+ */
+export const ShortInventory: Story = {
+    args: {
+        ...commonStoryArgs,
+        items: [
+            { ...garage, containerId: undefined },
+            { ...hammer, containerId: undefined },
+            { ...bike, containerId: undefined },
+        ],
+    },
+};
+
+/**
+ * High-volume fixture represents a real 100-plus-entry collection.
+ */
+export const HundredPlusInventory: Story = {
+    args: {
+        ...commonStoryArgs,
+        items: hundredPlusItems,
+    },
+};
 
 /**
  * Empty root level - no items at all

--- a/meteor-app/imports/ui/AllItemsView/AllItemsViewContainer.tsx
+++ b/meteor-app/imports/ui/AllItemsView/AllItemsViewContainer.tsx
@@ -8,10 +8,9 @@ import React, { type ComponentProps, type ReactElement, useState, useCallback, u
 import { useLocation } from 'wouter';
 
 import { InventoryItemsCollection, type InventoryItem } from '/imports/api/items';
+import { TagsCollection } from '/imports/api/tags';
 import type { SearchFragment } from '/imports/model/SearchFragment';
 import { AllItemsViewPresentation } from '/imports/ui/AllItemsView/AllItemsViewPresentation';
-import { LoadingState } from '/imports/ui/common/LoadingState';
-import { compareNaturalText } from '/imports/utility/naturalSort';
 import { useSubscribe, useTracker } from '/imports/utility/reactMeteorData';
 import { buildSearchQuery } from '/imports/utility/searchQuery';
 import { usePageTitle } from '/imports/utility/usePageTitle';
@@ -20,19 +19,6 @@ const REFRESH_VISUAL_DELAY_MS = 500;
 
 const findInventoryItemById = (itemId: string): InventoryItem | undefined => {
     return InventoryItemsCollection.find({ _id: itemId }, { limit: 1 }).fetch()[0];
-};
-
-const compareItemsForDisplay = (first: InventoryItem, second: InventoryItem): number => {
-    if (first.isContainer !== second.isContainer) {
-        return first.isContainer ? -1 : 1;
-    }
-
-    const byNaturalName = compareNaturalText(first.name, second.name);
-    if (byNaturalName !== 0) {
-        return byNaturalName;
-    }
-
-    return first.createdAt.getTime() - second.createdAt.getTime();
 };
 
 /**
@@ -117,12 +103,14 @@ export const AllItemsViewContainer = ({
                 $and: [baseQuery, filterQuery],
             };
 
-            return InventoryItemsCollection.find(combinedQuery).fetch().sort(compareItemsForDisplay);
+            return InventoryItemsCollection.find(combinedQuery).fetch();
         }
 
         // No filters - just show items at current level
-        return InventoryItemsCollection.find(baseQuery).fetch().sort(compareItemsForDisplay);
+        return InventoryItemsCollection.find(baseQuery).fetch();
     }, [currentContainerId, JSON.stringify(filters), refreshTrigger]);
+
+    const availableTags = useTracker(() => TagsCollection.find({}, { sort: { name: 1 } }).fetch(), []);
 
     // Fetch current container path for breadcrumb
     const containerPath = useTracker(() => {
@@ -156,15 +144,13 @@ export const AllItemsViewContainer = ({
         setLocation(containerId === undefined ? '/items' : `/container/${containerId}`);
     };
 
-    if (isLoadingItems() || isLoadingTags()) {
-        return <LoadingState />;
-    }
-
     return (
         <AllItemsViewPresentation
             {...rootElementProps}
             items={items}
             containerPath={containerPath}
+            availableTags={availableTags}
+            loading={isLoadingItems() || isLoadingTags()}
             onNavigateToContainer={(containerId) => {
                 handleNavigateToContainer(containerId);
             }}

--- a/meteor-app/imports/ui/AllItemsView/AllItemsViewPresentation.tsx
+++ b/meteor-app/imports/ui/AllItemsView/AllItemsViewPresentation.tsx
@@ -1,22 +1,28 @@
 /**
- * Presentational inventory list for the current container level.
- * Owns list-row semantics, touch gestures, breadcrumbs, and context-menu affordances,
- * while container modules provide data and routing callbacks.
+ * Presentational inventory browser for one container level.
+ * Owns the responsive sheet, scan metadata, sorting, row semantics, and touch gestures;
+ * Meteor subscriptions and route-level loading decisions stay in the container module.
  */
-import { Box, List, Text } from 'grommet';
-import { Folder, Next } from 'grommet-icons';
-import React, { type ComponentProps, type ReactElement, useRef } from 'react';
+import { Box } from 'grommet';
+import { Folder, Next, Package } from 'grommet-icons';
+import React, { type ComponentPropsWithoutRef, type ReactElement, useMemo, useRef, useState } from 'react';
 import styled, { css, keyframes } from 'styled-components';
 import { Link } from 'wouter';
 
 import type { InventoryItem } from '/imports/model/InventoryItem';
+import type { TagRecord } from '/imports/model/TagRecord';
+import {
+    inventorySortOptions,
+    type InventorySortOption,
+    sortInventoryItems,
+} from '/imports/ui/AllItemsView/inventorySort';
 import { BreadcrumbTrail } from '/imports/ui/BreadcrumbTrail';
 import { LoadingSpinner } from '/imports/ui/LoadingSpinner';
 import { LongPressContextMenu } from '/imports/ui/LongPressContextMenu';
+import { uiTokens } from '/imports/ui/theme';
 import { usePullToRefresh } from '/imports/utility/pullToRefresh';
 import { useSwipeNavigation } from '/imports/utility/swipeNavigation';
 
-// Pull-to-refresh and navigation constants
 const PULL_TRIGGER_DISTANCE_PX = 80;
 const PULL_MAX_VISUAL_DISTANCE_PX = 60;
 const ROTATION_MAX_DEGREES = 360;
@@ -24,77 +30,409 @@ const SWIPE_THRESHOLD_PX = 100;
 const SWIPE_EDGE_THRESHOLD_PX = 50;
 const SWIPE_MAX_VERTICAL_DEVIATION_PX = 50;
 const PARENT_CONTAINER_OFFSET = 2;
+const MAX_VISIBLE_TAGS = 2;
+const LOADING_ROW_COUNT = 6;
+const SKELETON_VARIANT_DIVISOR = 2;
 
 const noopRefresh = async (): Promise<void> => {
     return undefined;
 };
 
-/**
- * Scrollable container for items list
- */
+const Root = styled.div`
+    position: relative;
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    min-height: 0;
+    padding: ${uiTokens.space.sm};
+`;
+
 const ScrollableContainer = styled.div`
-    flex: 1;
+    flex: 1 1 auto;
+    min-height: 0;
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
 `;
 
-/**
- * Pull-to-refresh indicator container
- */
-const PullToRefreshIndicator = styled.div`
-    position: absolute;
-    top: 0;
-    left: 50%;
-    transform: translateX(-50%);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 44px;
-    height: 44px;
-    pointer-events: none;
-    z-index: 100;
-    transition: transform 0.2s ease-out, opacity 0.2s ease-out;
+const ContentFrame = styled.div`
+    width: min(100%, 1200px);
+    margin: 0 auto;
 `;
 
-const ItemRowLink = styled(Link)`
-    display: block;
+const InventorySheet = styled.section`
+    overflow: hidden;
+    border: 1px solid ${uiTokens.color.borderStrong};
+    border-radius: ${uiTokens.radius.control};
+    background: ${uiTokens.color.surfaceRaised};
+`;
+
+const InventoryToolbar = styled.div`
+    display: flex;
+    min-height: 64px;
+    align-items: center;
+    justify-content: space-between;
+    gap: ${uiTokens.space.lg};
+    padding: ${uiTokens.space.sm} ${uiTokens.space.lg};
+    border-bottom: 1px solid ${uiTokens.color.borderSubtle};
+    background: ${uiTokens.color.surfaceSunken};
+
+    @media (max-width: 599px) {
+        gap: ${uiTokens.space.md};
+        padding: ${uiTokens.space.sm} ${uiTokens.space.md};
+    }
+`;
+
+const InventoryCount = styled.div`
+    min-width: 0;
+`;
+
+const CountPrimary = styled.div`
+    color: ${uiTokens.color.text};
+    font-size: ${uiTokens.font.sizeMedium};
+    font-weight: ${uiTokens.font.weightSemibold};
+    line-height: ${uiTokens.font.lineHeightTight};
+`;
+
+const CountBreakdown = styled.div`
+    margin-top: ${uiTokens.space.xs};
+    overflow: hidden;
+    color: ${uiTokens.color.textWeak};
+    font-size: ${uiTokens.font.sizeXSmall};
+    line-height: ${uiTokens.font.lineHeightTight};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+`;
+
+const SortControl = styled.label`
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    gap: ${uiTokens.space.sm};
+    color: ${uiTokens.color.textWeak};
+    font-size: ${uiTokens.font.sizeSmall};
+    font-weight: ${uiTokens.font.weightMedium};
+
+    @media (max-width: 599px) {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: ${uiTokens.space.xxs};
+    }
+`;
+
+const SortSelect = styled.select`
+    min-width: 172px;
+    height: ${uiTokens.size.touchTarget};
+    min-height: ${uiTokens.size.touchTarget};
+    padding: 0 ${uiTokens.space.xxxl} 0 ${uiTokens.space.md};
+    border: 1px solid ${uiTokens.color.borderStrong};
+    border-radius: ${uiTokens.radius.control};
+    background: ${uiTokens.color.surfaceRaised};
+    color: ${uiTokens.color.text};
+    font: inherit;
+
+    @media (max-width: 599px) {
+        min-width: 158px;
+        max-width: 46vw;
+    }
+`;
+
+const inventoryColumns = css`
+    display: grid;
+    grid-template-columns: minmax(220px, 2.2fr) minmax(92px, 0.55fr) minmax(180px, 1.2fr) minmax(108px, 0.65fr) 24px;
+    gap: ${uiTokens.space.lg};
+`;
+
+const ColumnHeader = styled.div`
+    ${inventoryColumns};
+    align-items: center;
+    min-height: 36px;
+    padding: ${uiTokens.space.xs} ${uiTokens.space.lg};
+    border-bottom: 1px solid ${uiTokens.color.borderSubtle};
+    color: ${uiTokens.color.textMuted};
+    font-size: ${uiTokens.font.sizeXSmall};
+    font-weight: ${uiTokens.font.weightSemibold};
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+
+    @media (max-width: 899px) {
+        display: none;
+    }
+`;
+
+const InventoryList = styled.ul`
+    margin: 0;
+    padding: 0;
+    list-style: none;
+`;
+
+const InventoryListItem = styled.li`
+    margin: 0;
+    padding: 0;
+    border-bottom: 1px solid ${uiTokens.color.borderSubtle};
+
+    &:last-child {
+        border-bottom: 0;
+    }
+
+    > div {
+        display: block;
+        width: 100%;
+    }
+`;
+
+const ItemRowLink = styled(Link)<{ $isContainer: boolean }>`
+    ${inventoryColumns};
+    box-sizing: border-box;
+    width: 100%;
+    min-height: 62px;
+    align-items: center;
+    padding: ${uiTokens.space.sm} ${uiTokens.space.lg};
+    background: ${(props) => (props.$isContainer ? uiTokens.color.brandSubtle : uiTokens.color.surfaceRaised)};
     color: inherit;
     text-decoration: none;
+    transition: background ${uiTokens.motion.fast};
+
+    &:hover {
+        background: ${(props) => (props.$isContainer ? uiTokens.color.brandGhostActive : uiTokens.color.surfaceSunken)};
+    }
+
+    &:active {
+        background: ${uiTokens.color.surfaceSubtleActive};
+    }
 
     &:focus-visible {
-        outline: 3px solid #007aff;
-        outline-offset: 2px;
+        position: relative;
+        z-index: 1;
+        outline: ${uiTokens.focus.ring};
+        outline-offset: -2px;
+    }
+
+    @media (max-width: 899px) {
+        grid-template-columns: minmax(0, 1fr) 24px;
+        min-height: 68px;
+        gap: ${uiTokens.space.md};
+    }
+
+    @media (max-width: 599px) {
+        min-height: 64px;
+        padding: ${uiTokens.space.sm} ${uiTokens.space.md};
     }
 `;
 
-/**
- * Rotation animation for refresh icon
- */
+const NameCell = styled.div`
+    display: grid;
+    min-width: 0;
+    grid-template-columns: 24px minmax(0, 1fr);
+    align-items: center;
+    gap: ${uiTokens.space.md};
+`;
+
+const ItemIcon = styled.span<{ $isContainer: boolean }>`
+    display: inline-flex;
+    width: 24px;
+    height: 24px;
+    align-items: center;
+    justify-content: center;
+    color: ${(props) => (props.$isContainer ? uiTokens.color.brand : uiTokens.color.textMuted)};
+`;
+
+const NameStack = styled.div`
+    min-width: 0;
+`;
+
+const ItemName = styled.div<{ $isContainer: boolean }>`
+    overflow: hidden;
+    color: ${uiTokens.color.text};
+    font-size: ${uiTokens.font.sizeMedium};
+    font-weight: ${(props) => (props.$isContainer ? uiTokens.font.weightSemibold : uiTokens.font.weightMedium)};
+    line-height: ${uiTokens.font.lineHeightTight};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+`;
+
+const ItemDescription = styled.div`
+    margin-top: ${uiTokens.space.xs};
+    overflow: hidden;
+    color: ${uiTokens.color.textWeak};
+    font-size: ${uiTokens.font.sizeSmall};
+    line-height: ${uiTokens.font.lineHeightTight};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    @media (max-width: 899px) {
+        display: none;
+    }
+`;
+
+const CompactMetadata = styled.div`
+    display: none;
+    margin-top: ${uiTokens.space.xs};
+    overflow: hidden;
+    color: ${uiTokens.color.textWeak};
+    font-size: ${uiTokens.font.sizeSmall};
+    line-height: ${uiTokens.font.lineHeightTight};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    @media (max-width: 899px) {
+        display: block;
+    }
+`;
+
+const DesktopCell = styled.div`
+    min-width: 0;
+
+    @media (max-width: 899px) {
+        display: none;
+    }
+`;
+
+const TypeBadge = styled.span<{ $isContainer: boolean }>`
+    display: inline-flex;
+    align-items: center;
+    padding: ${uiTokens.space.xs} ${uiTokens.space.sm};
+    border-radius: ${uiTokens.radius.pill};
+    background: ${(props) => (props.$isContainer ? uiTokens.color.brandSubtle : uiTokens.color.surfaceSubtle)};
+    color: ${(props) => (props.$isContainer ? uiTokens.color.brandActive : uiTokens.color.textWeak)};
+    font-size: ${uiTokens.font.sizeXSmall};
+    font-weight: ${uiTokens.font.weightSemibold};
+    white-space: nowrap;
+`;
+
+const TagSummary = styled.div`
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: ${uiTokens.space.xs};
+    overflow: hidden;
+`;
+
+const TagPill = styled.span`
+    display: inline-block;
+    max-width: 112px;
+    overflow: hidden;
+    padding: ${uiTokens.space.xs} ${uiTokens.space.sm};
+    border-radius: ${uiTokens.radius.pill};
+    background: ${uiTokens.color.surfaceSubtle};
+    color: ${uiTokens.color.textWeak};
+    font-size: ${uiTokens.font.sizeXSmall};
+    line-height: ${uiTokens.font.lineHeightTight};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+`;
+
+const NoMetadata = styled.span`
+    color: ${uiTokens.color.textMuted};
+    font-size: ${uiTokens.font.sizeSmall};
+`;
+
+const UpdatedText = styled.time`
+    display: block;
+    overflow: hidden;
+    color: ${uiTokens.color.textWeak};
+    font-size: ${uiTokens.font.sizeSmall};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+`;
+
+const RowChevron = styled.span`
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: ${uiTokens.color.textMuted};
+`;
+
+const EmptyState = styled.div`
+    display: flex;
+    min-height: 180px;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: ${uiTokens.space.sm};
+    padding: ${uiTokens.space.xxxl};
+    color: ${uiTokens.color.textWeak};
+    text-align: center;
+`;
+
+const EmptyTitle = styled.div`
+    color: ${uiTokens.color.text};
+    font-weight: ${uiTokens.font.weightSemibold};
+`;
+
+const EmptyHint = styled.div`
+    font-size: ${uiTokens.font.sizeSmall};
+`;
+
+const skeletonPulse = keyframes`
+    0%, 100% { opacity: 0.45; }
+    50% { opacity: 0.8; }
+`;
+
+const SkeletonRow = styled.div`
+    ${inventoryColumns};
+    min-height: 62px;
+    align-items: center;
+    padding: ${uiTokens.space.sm} ${uiTokens.space.lg};
+    border-bottom: 1px solid ${uiTokens.color.borderSubtle};
+
+    &:last-child {
+        border-bottom: 0;
+    }
+
+    @media (max-width: 899px) {
+        grid-template-columns: minmax(0, 1fr) 24px;
+        min-height: 68px;
+    }
+`;
+
+const SkeletonBar = styled.div<{ $width: string }>`
+    width: ${(props) => props.$width};
+    max-width: 100%;
+    height: 12px;
+    border-radius: ${uiTokens.radius.small};
+    background: ${uiTokens.color.borderSubtle};
+    animation: ${skeletonPulse} 1.2s ease-in-out infinite;
+
+    @media (max-width: 899px) {
+        &:not(:first-child) {
+            display: none;
+        }
+    }
+`;
+
+const PullToRefreshIndicator = styled.div`
+    position: absolute;
+    z-index: 100;
+    top: 0;
+    left: 50%;
+    display: flex;
+    width: ${uiTokens.size.touchTarget};
+    height: ${uiTokens.size.touchTarget};
+    align-items: center;
+    justify-content: center;
+    transform: translateX(-50%);
+    pointer-events: none;
+    transition: transform ${uiTokens.motion.standard}, opacity ${uiTokens.motion.standard};
+`;
+
 const rotate = keyframes`
-    from {
-        transform: rotate(0deg);
-    }
-    to {
-        transform: rotate(360deg);
-    }
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
 `;
 
-/**
- * Refresh icon arrow (SVG)
- */
 const RefreshIcon = styled.svg.attrs<{ isTriggered: boolean; pullDistance: number }>(() => ({
     viewBox: '0 0 24 24',
     width: '24',
     height: '24',
 }))<{ isTriggered: boolean; pullDistance: number }>`
     fill: none;
-    stroke: ${(props) => (props.isTriggered ? '#7D4CDB' : '#999')};
+    stroke: ${(props) => (props.isTriggered ? uiTokens.color.brand : uiTokens.color.textMuted)};
     stroke-width: 2;
     stroke-linecap: round;
     stroke-linejoin: round;
     transform: rotate(${(props) =>
         Math.min((props.pullDistance / PULL_TRIGGER_DISTANCE_PX) * ROTATION_MAX_DEGREES, ROTATION_MAX_DEGREES)}deg);
-    transition: stroke 0.2s ease-out;
+    transition: stroke ${uiTokens.motion.standard};
 
     ${(props) =>
         props.isTriggered
@@ -104,72 +442,33 @@ const RefreshIcon = styled.svg.attrs<{ isTriggered: boolean; pullDistance: numbe
             : undefined}
 `;
 
-/**
- * AllItemsViewPresentation is a pure presentation component that displays inventory items
- * in a hierarchical structure.
- *
- * This component receives all data as props and has no dependencies on Meteor's reactive
- * data system, making it fully testable in Storybook.
- *
- * Features:
- * - Shows items at the current container level
- * - BreadcrumbTrail for navigation context
- * - Visual distinction between containers (Folder icon) and items
- * - Touch-optimized navigation (44x44px minimum touch targets)
- * - Pull-to-refresh gesture for iOS-style data refresh
- * - Long-press context menus on items for actions
- * - Click containers to navigate into them
- */
 export interface AllItemsViewPresentationProps {
-    /**
-     * Items to display at the current level
-     */
     items: InventoryItem[];
-
-    /**
-     * Path of containers from root to current location for breadcrumb
-     */
     containerPath: InventoryItem[];
-
-    /**
-     * Whether to show the home icon in breadcrumb
-     */
+    availableTags?: TagRecord[];
+    loading?: boolean;
     showHomeIcon?: boolean;
-
-    /**
-     * Callback when a container is clicked to navigate into it
-     */
     onNavigateToContainer: (containerId: string) => void;
-
-    /**
-     * Callback when navigating via breadcrumb trail
-     */
     onBreadcrumbNavigate: (containerId: string | undefined) => void;
-
-    /**
-     * Callback when pull-to-refresh is triggered
-     */
     onRefresh?: () => Promise<void>;
-
-    /**
-     * Callback when item edit is selected from context menu
-     */
     onEditItem?: (itemId: string) => void;
-
-    /**
-     * Callback when item delete is selected from context menu
-     */
     onDeleteItem?: (itemId: string) => void;
-
-    /**
-     * Callback when item view details is selected from context menu
-     */
     onViewItemDetails?: (itemId: string) => void;
 }
+
+const formatCount = (count: number, singular: string, plural: string): string => {
+    return `${count} ${count === 1 ? singular : plural}`;
+};
+
+const formatUpdatedDate = (date: Date): string => {
+    return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric', year: 'numeric' }).format(date);
+};
 
 export const AllItemsViewPresentation = ({
     items,
     containerPath,
+    availableTags = [],
+    loading = false,
     showHomeIcon = true,
     onNavigateToContainer,
     onBreadcrumbNavigate,
@@ -178,10 +477,14 @@ export const AllItemsViewPresentation = ({
     onDeleteItem,
     onViewItemDetails,
     ...rootElementProps
-}: AllItemsViewPresentationProps & ComponentProps<'div'>): ReactElement => {
+}: AllItemsViewPresentationProps & ComponentPropsWithoutRef<'div'>): ReactElement => {
     const containerRef = useRef<HTMLDivElement>(null);
+    const [sortOption, setSortOption] = useState<InventorySortOption>('name-asc');
+    const sortedItems = useMemo(() => sortInventoryItems(items, sortOption), [items, sortOption]);
+    const tagNamesById = useMemo(() => new Map(availableTags.map((tag) => [tag._id, tag.name])), [availableTags]);
+    const containerCount = items.filter((item) => item.isContainer).length;
+    const itemCount = items.length - containerCount;
 
-    // Pull-to-refresh hook
     const { isRefreshing, pullDistance, isTriggered } = usePullToRefresh({
         containerRef,
         onRefresh: onRefresh ?? noopRefresh,
@@ -189,8 +492,6 @@ export const AllItemsViewPresentation = ({
         enabled: onRefresh !== undefined,
     });
 
-    // Swipe-back navigation hook
-    // Navigate to parent container (second-to-last in breadcrumb path)
     const hasParent = containerPath.length > 0;
     const parentContainerId =
         containerPath.length >= PARENT_CONTAINER_OFFSET
@@ -206,14 +507,12 @@ export const AllItemsViewPresentation = ({
             maxVerticalDeviation: SWIPE_MAX_VERTICAL_DEVIATION_PX,
         },
         () => {
-            // Navigate to parent container
             onBreadcrumbNavigate(parentContainerId);
         }
     );
 
     return (
-        <Box {...rootElementProps} fill gap="small" pad="small">
-            {/* Pull-to-refresh indicator */}
+        <Root {...rootElementProps}>
             {onRefresh !== undefined && (
                 <PullToRefreshIndicator
                     data-testid="pull-to-refresh-indicator"
@@ -236,104 +535,218 @@ export const AllItemsViewPresentation = ({
                 </PullToRefreshIndicator>
             )}
 
-            {/* Scrollable container */}
             <ScrollableContainer ref={containerRef} data-testid="items-list">
-                {/* Breadcrumb trail for navigation */}
-                <BreadcrumbTrail
-                    path={containerPath}
-                    showHomeIcon={showHomeIcon}
-                    onNavigateRoot={() => {
-                        onBreadcrumbNavigate(undefined);
-                    }}
-                    onNavigate={(item) => {
-                        onBreadcrumbNavigate(item._id);
-                    }}
-                />
-
-                {/* Items list */}
-                {items.length === 0 ? (
-                    <Box align="center" justify="center" pad="large">
-                        <Text color="text-weak">No items at this level</Text>
-                    </Box>
-                ) : (
-                    <List data={items} pad="none" border={false}>
-                        {(item: InventoryItem) => {
-                            // Build context menu actions
-                            const menuActions = [];
-
-                            // Always add View Details - navigates to /items/:itemId
-                            if (onViewItemDetails !== undefined) {
-                                menuActions.push({
-                                    label: 'View Details',
-                                    onClick: () => {
-                                        onViewItemDetails(item._id);
-                                    },
-                                });
-                            }
-
-                            if (onEditItem !== undefined) {
-                                menuActions.push({
-                                    label: 'Edit',
-                                    onClick: () => {
-                                        onEditItem(item._id);
-                                    },
-                                });
-                            }
-
-                            if (onDeleteItem !== undefined) {
-                                menuActions.push({
-                                    label: 'Delete',
-                                    onClick: () => {
-                                        onDeleteItem(item._id);
-                                    },
-                                    variant: 'danger' as const,
-                                });
-                            }
-                            return (
-                                <LongPressContextMenu key={item._id} actions={menuActions}>
-                                    <ItemRowLink
-                                        href={item.isContainer ? `/container/${item._id}` : `/items/${item._id}`}
-                                        aria-label={
-                                            item.isContainer ? `Open container ${item.name}` : `View item ${item.name}`
-                                        }
-                                    >
-                                        <Box
-                                            direction="row"
-                                            align="center"
-                                            pad="small"
-                                            gap="small"
-                                            background="background-front"
-                                            hoverIndicator="background-contrast"
-                                            style={{
-                                                minHeight: '44px',
-                                                cursor: 'pointer',
-                                            }}
-                                        >
-                                            {/* Icon for containers */}
-                                            {item.isContainer && <Folder size="medium" color="brand" />}
-
-                                            {/* Item name */}
-                                            <Box flex style={{ minWidth: 0 }}>
-                                                <Text weight={item.isContainer ? 'bold' : 'normal'} truncate>
-                                                    {item.name}
-                                                </Text>
-                                                {item.description !== '' && item.description !== undefined && (
-                                                    <Text size="small" color="text-weak" truncate>
-                                                        {item.description}
-                                                    </Text>
-                                                )}
-                                            </Box>
-
-                                            {/* Navigation arrow for containers */}
-                                            {item.isContainer && <Next size="medium" color="text-weak" />}
-                                        </Box>
-                                    </ItemRowLink>
-                                </LongPressContextMenu>
-                            );
+                <ContentFrame>
+                    <BreadcrumbTrail
+                        path={containerPath}
+                        showHomeIcon={showHomeIcon}
+                        onNavigateRoot={() => {
+                            onBreadcrumbNavigate(undefined);
                         }}
-                    </List>
-                )}
+                        onNavigate={(item) => {
+                            onBreadcrumbNavigate(item._id);
+                        }}
+                    />
+
+                    <InventorySheet aria-label="Inventory entries">
+                        <InventoryToolbar>
+                            <InventoryCount aria-live="polite" data-testid="inventory-count">
+                                <CountPrimary>
+                                    {loading ? 'Loading inventory…' : formatCount(items.length, 'entry', 'entries')}
+                                </CountPrimary>
+                                <CountBreakdown>
+                                    {loading
+                                        ? 'Fetching this location'
+                                        : `${formatCount(containerCount, 'container', 'containers')} • ${formatCount(
+                                              itemCount,
+                                              'item',
+                                              'items'
+                                          )}`}
+                                </CountBreakdown>
+                            </InventoryCount>
+
+                            <SortControl>
+                                <span>Sort</span>
+                                <SortSelect
+                                    aria-label="Sort inventory"
+                                    value={sortOption}
+                                    disabled={loading}
+                                    onChange={(event) => {
+                                        setSortOption(event.currentTarget.value as InventorySortOption);
+                                    }}
+                                >
+                                    {inventorySortOptions.map((option) => (
+                                        <option key={option.value} value={option.value}>
+                                            {option.label}
+                                        </option>
+                                    ))}
+                                </SortSelect>
+                            </SortControl>
+                        </InventoryToolbar>
+
+                        <ColumnHeader aria-hidden="true">
+                            <span>Name</span>
+                            <span>Type</span>
+                            <span>Tags</span>
+                            <span>Updated</span>
+                            <span />
+                        </ColumnHeader>
+
+                        {loading ? (
+                            <Box role="status" aria-label="Loading inventory entries">
+                                {Array.from({ length: LOADING_ROW_COUNT }, (_, index) => (
+                                    <SkeletonRow key={index} aria-hidden="true">
+                                        <SkeletonBar $width={index % SKELETON_VARIANT_DIVISOR === 0 ? '72%' : '56%'} />
+                                        <SkeletonBar $width="68px" />
+                                        <SkeletonBar $width="82%" />
+                                        <SkeletonBar $width="76px" />
+                                        <span />
+                                    </SkeletonRow>
+                                ))}
+                            </Box>
+                        ) : sortedItems.length === 0 ? (
+                            <EmptyState role="status">
+                                <EmptyTitle>No items at this level</EmptyTitle>
+                                <EmptyHint>
+                                    Create an item or adjust the active filters to add something here.
+                                </EmptyHint>
+                            </EmptyState>
+                        ) : (
+                            <InventoryList>
+                                {sortedItems.map((item) => {
+                                    const menuActions = [];
+                                    if (onViewItemDetails !== undefined) {
+                                        menuActions.push({
+                                            label: 'View Details',
+                                            onClick: () => {
+                                                onViewItemDetails(item._id);
+                                            },
+                                        });
+                                    }
+                                    if (onEditItem !== undefined) {
+                                        menuActions.push({
+                                            label: 'Edit',
+                                            onClick: () => {
+                                                onEditItem(item._id);
+                                            },
+                                        });
+                                    }
+                                    if (onDeleteItem !== undefined) {
+                                        menuActions.push({
+                                            label: 'Delete',
+                                            onClick: () => {
+                                                onDeleteItem(item._id);
+                                            },
+                                            variant: 'danger' as const,
+                                        });
+                                    }
+
+                                    const tagNames = item.tagIds.map((tagId) => tagNamesById.get(tagId) ?? tagId);
+                                    const compactDetail =
+                                        item.description?.trim() !== '' && item.description !== undefined
+                                            ? item.description
+                                            : tagNames.length > 0
+                                            ? tagNames.join(', ')
+                                            : 'No additional details';
+
+                                    return (
+                                        <InventoryListItem key={item._id}>
+                                            <LongPressContextMenu actions={menuActions}>
+                                                <ItemRowLink
+                                                    $isContainer={item.isContainer}
+                                                    data-testid="inventory-row"
+                                                    data-container={String(item.isContainer)}
+                                                    href={
+                                                        item.isContainer
+                                                            ? `/container/${item._id}`
+                                                            : `/items/${item._id}`
+                                                    }
+                                                    aria-label={
+                                                        item.isContainer
+                                                            ? `Open container ${item.name}`
+                                                            : `View item ${item.name}`
+                                                    }
+                                                >
+                                                    <NameCell>
+                                                        <ItemIcon $isContainer={item.isContainer} aria-hidden="true">
+                                                            {item.isContainer ? (
+                                                                <Folder size="20px" color="currentColor" />
+                                                            ) : (
+                                                                <Package size="20px" color="currentColor" />
+                                                            )}
+                                                        </ItemIcon>
+                                                        <NameStack>
+                                                            <ItemName $isContainer={item.isContainer} title={item.name}>
+                                                                {item.name}
+                                                            </ItemName>
+                                                            {item.description !== '' &&
+                                                                item.description !== undefined && (
+                                                                    <ItemDescription title={item.description}>
+                                                                        {item.description}
+                                                                    </ItemDescription>
+                                                                )}
+                                                            <CompactMetadata
+                                                                title={`${
+                                                                    item.isContainer ? 'Container' : 'Item'
+                                                                } • ${compactDetail}`}
+                                                            >
+                                                                {item.isContainer ? 'Container' : 'Item'} •{' '}
+                                                                {compactDetail}
+                                                            </CompactMetadata>
+                                                        </NameStack>
+                                                    </NameCell>
+
+                                                    <DesktopCell>
+                                                        <TypeBadge $isContainer={item.isContainer}>
+                                                            {item.isContainer ? 'Container' : 'Item'}
+                                                        </TypeBadge>
+                                                    </DesktopCell>
+
+                                                    <DesktopCell>
+                                                        {tagNames.length === 0 ? (
+                                                            <NoMetadata>No tags</NoMetadata>
+                                                        ) : (
+                                                            <TagSummary title={tagNames.join(', ')}>
+                                                                {tagNames
+                                                                    .slice(0, MAX_VISIBLE_TAGS)
+                                                                    .map((tagName, index) => (
+                                                                        <TagPill
+                                                                            key={`${item._id}-${item.tagIds[index]}`}
+                                                                        >
+                                                                            {tagName}
+                                                                        </TagPill>
+                                                                    ))}
+                                                                {tagNames.length > MAX_VISIBLE_TAGS && (
+                                                                    <TagPill>
+                                                                        +{tagNames.length - MAX_VISIBLE_TAGS}
+                                                                    </TagPill>
+                                                                )}
+                                                            </TagSummary>
+                                                        )}
+                                                    </DesktopCell>
+
+                                                    <DesktopCell>
+                                                        <UpdatedText
+                                                            dateTime={item.modifiedAt.toISOString()}
+                                                            title={item.modifiedAt.toLocaleString()}
+                                                        >
+                                                            {formatUpdatedDate(item.modifiedAt)}
+                                                        </UpdatedText>
+                                                    </DesktopCell>
+
+                                                    <RowChevron aria-hidden="true">
+                                                        <Next size="18px" color="currentColor" />
+                                                    </RowChevron>
+                                                </ItemRowLink>
+                                            </LongPressContextMenu>
+                                        </InventoryListItem>
+                                    );
+                                })}
+                            </InventoryList>
+                        )}
+                    </InventorySheet>
+                </ContentFrame>
             </ScrollableContainer>
-        </Box>
+        </Root>
     );
 };

--- a/meteor-app/imports/ui/AllItemsView/inventorySort.test.ts
+++ b/meteor-app/imports/ui/AllItemsView/inventorySort.test.ts
@@ -1,0 +1,63 @@
+import { expect } from 'chai';
+
+import type { InventoryItem } from '/imports/model/InventoryItem';
+import { sortInventoryItems } from '/imports/ui/AllItemsView/inventorySort';
+
+const item = (
+    name: string,
+    options: { isContainer?: boolean; createdAt?: string; modifiedAt?: string } = {}
+): InventoryItem => ({
+    _id: name,
+    name,
+    isContainer: options.isContainer ?? false,
+    tagIds: [],
+    createdAt: new Date(options.createdAt ?? '2026-01-01T00:00:00Z'),
+    modifiedAt: new Date(options.modifiedAt ?? '2026-01-01T00:00:00Z'),
+});
+
+describe('inventorySort', function () {
+    it('keeps containers first and applies natural ascending names', function () {
+        const result = sortInventoryItems(
+            [
+                item('Cable 10'),
+                item('Box 10', { isContainer: true }),
+                item('Cable 2'),
+                item('Box 2', { isContainer: true }),
+            ],
+            'name-asc'
+        );
+
+        expect(result.map(({ name }) => name)).to.deep.equal(['Box 2', 'Box 10', 'Cable 2', 'Cable 10']);
+    });
+
+    it('keeps containers first while reversing names within each type', function () {
+        const result = sortInventoryItems(
+            [
+                item('Cable 10'),
+                item('Box 10', { isContainer: true }),
+                item('Cable 2'),
+                item('Box 2', { isContainer: true }),
+            ],
+            'name-desc'
+        );
+
+        expect(result.map(({ name }) => name)).to.deep.equal(['Box 10', 'Box 2', 'Cable 10', 'Cable 2']);
+    });
+
+    it('sorts all entries by modified time for recent and oldest options', function () {
+        const olderContainer = item('Older container', {
+            isContainer: true,
+            modifiedAt: '2026-01-01T00:00:00Z',
+        });
+        const newerItem = item('Newer item', { modifiedAt: '2026-02-01T00:00:00Z' });
+
+        expect(sortInventoryItems([olderContainer, newerItem], 'updated-desc').map(({ name }) => name)).to.deep.equal([
+            'Newer item',
+            'Older container',
+        ]);
+        expect(sortInventoryItems([olderContainer, newerItem], 'updated-asc').map(({ name }) => name)).to.deep.equal([
+            'Older container',
+            'Newer item',
+        ]);
+    });
+});

--- a/meteor-app/imports/ui/AllItemsView/inventorySort.ts
+++ b/meteor-app/imports/ui/AllItemsView/inventorySort.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure sorting rules for the browsable inventory sheet.
+ * Kept separate so Storybook, the Meteor container, and unit tests share one
+ * deterministic definition without coupling sort behavior to React state.
+ */
+import type { InventoryItem } from '/imports/model/InventoryItem';
+import { compareNaturalText } from '/imports/utility/naturalSort';
+
+export const inventorySortOptions = [
+    { value: 'name-asc', label: 'Name (A–Z)' },
+    { value: 'name-desc', label: 'Name (Z–A)' },
+    { value: 'updated-desc', label: 'Recently updated' },
+    { value: 'updated-asc', label: 'Oldest updated' },
+] as const;
+
+export type InventorySortOption = (typeof inventorySortOptions)[number]['value'];
+
+const compareContainerType = (first: InventoryItem, second: InventoryItem): number => {
+    if (first.isContainer === second.isContainer) return 0;
+    return first.isContainer ? -1 : 1;
+};
+
+const compareStableFallback = (first: InventoryItem, second: InventoryItem): number => {
+    const byName = compareNaturalText(first.name, second.name);
+    if (byName !== 0) return byName;
+    return first.createdAt.getTime() - second.createdAt.getTime();
+};
+
+export const compareInventoryItems = (
+    first: InventoryItem,
+    second: InventoryItem,
+    sortOption: InventorySortOption
+): number => {
+    if (sortOption === 'name-asc' || sortOption === 'name-desc') {
+        const byContainerType = compareContainerType(first, second);
+        if (byContainerType !== 0) return byContainerType;
+
+        const byName = compareNaturalText(first.name, second.name);
+        if (byName !== 0) return sortOption === 'name-desc' ? -byName : byName;
+        return first.createdAt.getTime() - second.createdAt.getTime();
+    }
+
+    const byModifiedDate = first.modifiedAt.getTime() - second.modifiedAt.getTime();
+    if (byModifiedDate !== 0) return sortOption === 'updated-desc' ? -byModifiedDate : byModifiedDate;
+
+    return compareStableFallback(first, second);
+};
+
+export const sortInventoryItems = (items: InventoryItem[], sortOption: InventorySortOption): InventoryItem[] => {
+    return [...items].sort((first, second) => compareInventoryItems(first, second, sortOption));
+};

--- a/meteor-app/imports/ui/App.tsx
+++ b/meteor-app/imports/ui/App.tsx
@@ -6,6 +6,7 @@ import { Box, Button, Grommet, Heading, Text } from 'grommet';
 import { Add, Filter } from 'grommet-icons';
 import { Meteor } from 'meteor/meteor';
 import React, { type ReactElement, useState, useEffect } from 'react';
+import styled from 'styled-components';
 import { Route, Switch, useLocation } from 'wouter';
 
 import Items, { InventoryItemsCollection } from '/imports/api/items';
@@ -30,9 +31,37 @@ import { SearchFragmentBuilder } from './SearchFragmentBuilder';
 import { SearchResultsView } from './SearchResultsView';
 import { SearchScopeSelector } from './SearchScopeSelector';
 import { SettingsDataView } from './SettingsDataView';
-import { DesignSystemGlobalStyle, theme } from './theme';
+import { DesignSystemGlobalStyle, theme, uiTokens } from './theme';
 
 const SEARCH_RESULT_ITEM_DETAIL_SOURCE = 'search-results';
+
+const ItemsViewHeader = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: ${uiTokens.space.lg};
+    margin-bottom: ${uiTokens.space.lg};
+
+    @media (max-width: 599px) {
+        align-items: stretch;
+        flex-direction: column;
+        gap: ${uiTokens.space.md};
+    }
+`;
+
+const ItemsViewActions = styled.div`
+    display: flex;
+    gap: ${uiTokens.space.sm};
+
+    @media (max-width: 599px) {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+
+        > button {
+            width: 100%;
+        }
+    }
+`;
 
 interface ItemDetailNavigationState {
     inventoryItemDetailSource?: typeof SEARCH_RESULT_ITEM_DETAIL_SOURCE;
@@ -235,11 +264,11 @@ export const App = (): ReactElement => {
     const renderItemsView = (initialContainerId?: string): ReactElement => {
         return (
             <Box fill style={{ minHeight: 0 }}>
-                <Box direction="row" justify="between" align="center" margin={{ bottom: 'medium' }} flex={false}>
+                <ItemsViewHeader>
                     <Heading level="2" margin="none">
                         {getItemsViewHeading(initialContainerId)}
                     </Heading>
-                    <Box direction="row" gap="small">
+                    <ItemsViewActions>
                         <Button
                             icon={<Filter />}
                             label={showFilterBuilder ? 'Hide Filters' : 'Add Filters'}
@@ -257,8 +286,8 @@ export const App = (): ReactElement => {
                                 setShowCreateItem(true);
                             }}
                         />
-                    </Box>
-                </Box>
+                    </ItemsViewActions>
+                </ItemsViewHeader>
 
                 {/* Filter status and clear */}
                 {itemsViewFilters.length > 0 && (

--- a/meteor-app/server/test-helpers.ts
+++ b/meteor-app/server/test-helpers.ts
@@ -9,13 +9,21 @@ import { Meteor } from 'meteor/meteor';
 import { WebApp } from 'meteor/webapp';
 
 import { Attachments } from '/imports/api/attachments';
-import Items from '/imports/api/items';
-import Tags from '/imports/api/tags';
+import Items, { InventoryItemsCollection } from '/imports/api/items';
+import Tags, { createTag } from '/imports/api/tags';
 
 // HTTP status codes
 const HTTP_OK = 200;
 const HTTP_METHOD_NOT_ALLOWED = 405;
 const HTTP_INTERNAL_SERVER_ERROR = 500;
+const MAX_SCANNING_FIXTURE_ITEMS = 500;
+const SCANNING_FIXTURE_CONTAINER_COUNT = 2;
+const SCANNING_FIXTURE_DESCRIPTION_INTERVAL = 3;
+const SCANNING_FIXTURE_MULTI_TAG_INTERVAL = 5;
+const SCANNING_FIXTURE_SINGLE_TAG_INTERVAL = 2;
+const SCANNING_FIXTURE_YEAR = 2026;
+const SCANNING_FIXTURE_MONTH = 0;
+const SCANNING_FIXTURE_DAY_RANGE = 28;
 
 const TEST_RESET_ENABLED = process.env.E2E_RESET_DATABASE === '1';
 
@@ -78,6 +86,83 @@ if (!Meteor.isProduction) {
          */
         async 'test.resetDatabase'(): Promise<void> {
             await resetDatabase();
+        },
+
+        async 'test.seedInventoryScanningFixture'(standardItemCount: number): Promise<{
+            totalCount: number;
+            containerCount: number;
+            itemCount: number;
+        }> {
+            assertTestDatabaseMutationAllowed();
+
+            if (
+                !Number.isInteger(standardItemCount) ||
+                standardItemCount < 1 ||
+                standardItemCount > MAX_SCANNING_FIXTURE_ITEMS
+            ) {
+                throw new Meteor.Error('invalid-argument', 'standardItemCount must be an integer from 1 to 500');
+            }
+
+            const toolsTagId = await createTag({ name: 'Tools' });
+            const storageTagId = await createTag({ name: 'Storage' });
+            const now = new Date('2026-01-01T00:00:00.000Z');
+            const containerCount = SCANNING_FIXTURE_CONTAINER_COUNT;
+
+            await Promise.all([
+                InventoryItemsCollection.insertAsync({
+                    name: 'Garage',
+                    description: 'Workshop and storage area',
+                    isContainer: true,
+                    tagIds: [storageTagId],
+                    createdAt: now,
+                    modifiedAt: now,
+                }),
+                InventoryItemsCollection.insertAsync({
+                    name: 'Utility Closet',
+                    description: 'Household supplies and tools',
+                    isContainer: true,
+                    tagIds: [storageTagId, toolsTagId],
+                    createdAt: now,
+                    modifiedAt: now,
+                }),
+            ]);
+
+            await Promise.all(
+                Array.from({ length: standardItemCount }, async (_, index) => {
+                    const itemNumber = index + 1;
+                    return await InventoryItemsCollection.insertAsync({
+                        name:
+                            itemNumber === 1
+                                ? 'A very long inventory name that must truncate predictably at desktop tablet and phone widths'
+                                : `Inventory item ${itemNumber}`,
+                        description:
+                            itemNumber % SCANNING_FIXTURE_DESCRIPTION_INTERVAL === 0
+                                ? `Comparison description for item ${itemNumber}`
+                                : undefined,
+                        isContainer: false,
+                        tagIds:
+                            itemNumber % SCANNING_FIXTURE_MULTI_TAG_INTERVAL === 0
+                                ? [toolsTagId, storageTagId]
+                                : itemNumber % SCANNING_FIXTURE_SINGLE_TAG_INTERVAL === 0
+                                ? [storageTagId]
+                                : [],
+                        createdAt: now,
+                        modifiedAt: new Date(
+                            Date.UTC(
+                                SCANNING_FIXTURE_YEAR,
+                                SCANNING_FIXTURE_MONTH,
+                                (itemNumber % SCANNING_FIXTURE_DAY_RANGE) + 1
+                            )
+                        ),
+                    });
+                })
+            );
+
+            return {
+                totalCount: standardItemCount + containerCount,
+                containerCount,
+                itemCount: standardItemCount,
+            };
         },
 
         async 'test.forceItemContainer'(itemId: string, containerId: string): Promise<number> {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -24,6 +24,7 @@ const isStorybookOnlyRun =
     (selectedProjects.length > 0 && selectedProjects.every((project) => project === 'storybook-chromium'));
 const appPort = process.env.PLAYWRIGHT_APP_PORT ?? '3000';
 const appBaseURL = process.env.PLAYWRIGHT_APP_BASE_URL ?? `http://localhost:${appPort}`;
+const storybookBaseURL = process.env.PLAYWRIGHT_STORYBOOK_BASE_URL ?? 'http://localhost:6006';
 const meteorLocalDir =
     process.env.PLAYWRIGHT_METEOR_LOCAL_DIR === undefined
         ? ''
@@ -41,7 +42,7 @@ const appWebServer = {
 
 const storybookWebServer = {
     command: 'npm run storybook',
-    url: 'http://localhost:6006',
+    url: storybookBaseURL,
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,
     stdout: 'pipe',
@@ -118,7 +119,7 @@ export default defineConfig({
             name: 'storybook-chromium',
             use: {
                 ...devices['Desktop Chrome'],
-                baseURL: 'http://localhost:6006',
+                baseURL: storybookBaseURL,
             },
             testMatch: /tests\/e2e\/storybook\/.*\.spec\.ts/,
         },

--- a/tests/e2e/app/inventory-density.spec.ts
+++ b/tests/e2e/app/inventory-density.spec.ts
@@ -1,0 +1,117 @@
+import { expect, test } from '@playwright/test';
+
+import { callMeteorMethod, resetDatabase, waitForMeteorReady } from '../helpers/database';
+
+const highVolumeItemCount = 103;
+const highVolumeTotalCount = highVolumeItemCount + 2;
+const highVolumeTestTimeoutMs = 60_000;
+const longItemName = 'A very long inventory name that must truncate predictably at desktop tablet and phone widths';
+
+const seedHighVolumeInventory = async (page: Parameters<typeof callMeteorMethod>[0]): Promise<void> => {
+    await callMeteorMethod(page, 'test.seedInventoryScanningFixture', highVolumeItemCount);
+    await page.goto('/items');
+    await waitForMeteorReady(page);
+    await expect(page.getByTestId('inventory-count')).toContainText(`${highVolumeTotalCount} entries`);
+};
+
+test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForMeteorReady(page);
+    await resetDatabase(page);
+    await page.goto('/items');
+    await waitForMeteorReady(page);
+});
+
+test.describe('Responsive inventory density', () => {
+    test.describe.configure({ timeout: highVolumeTestTimeoutMs });
+
+    test('keeps count and sort context in the empty app state', async ({ page }) => {
+        await expect(page.getByTestId('inventory-count')).toContainText('0 entries');
+        await expect(page.getByTestId('inventory-count')).toContainText('0 containers • 0 items');
+        await expect(page.getByRole('combobox', { name: 'Sort inventory' })).toBeEnabled();
+        await expect(page.getByText('No items at this level')).toBeVisible();
+    });
+
+    test('supports high-volume comparison and explicit sorting on desktop', async ({ page }) => {
+        await page.setViewportSize({ width: 1440, height: 900 });
+        await seedHighVolumeInventory(page);
+
+        await expect(page.getByTestId('inventory-count')).toContainText('2 containers • 103 items');
+        await expect(page.getByTestId('items-list').getByRole('link')).toHaveCount(highVolumeTotalCount);
+        const inventoryList = page.getByTestId('items-list');
+        await expect(inventoryList.getByText('Type', { exact: true })).toBeVisible();
+        await expect(inventoryList.getByText('Tags', { exact: true })).toBeVisible();
+        await expect(inventoryList.getByText('Updated', { exact: true })).toBeVisible();
+
+        const garageRow = page.getByRole('link', { name: 'Open container Garage' });
+        await expect(garageRow).toContainText('Workshop and storage area');
+        await expect(garageRow).toContainText('Container');
+        await expect(garageRow).toContainText('Storage');
+        await expect(garageRow.locator('time')).toHaveAttribute('datetime', '2026-01-01T00:00:00.000Z');
+
+        await page.getByRole('combobox', { name: 'Sort inventory' }).selectOption('name-desc');
+        const sortedRowNames = await page
+            .getByTestId('items-list')
+            .getByRole('link')
+            .evaluateAll((links) => links.slice(0, 2).map((link) => link.getAttribute('aria-label')));
+        expect(sortedRowNames).toEqual(['Open container Utility Closet', 'Open container Garage']);
+
+        const sheetBox = await page.getByRole('region', { name: 'Inventory entries' }).boundingBox();
+        if (sheetBox === null) throw new Error('Inventory sheet is not visible');
+        expect(sheetBox.width).toBeLessThanOrEqual(1202);
+    });
+
+    test('preserves scan metadata, truncation, touch rows, and no overflow at required widths', async ({ page }) => {
+        await seedHighVolumeInventory(page);
+
+        for (const viewport of [
+            { width: 1440, height: 900 },
+            { width: 768, height: 1024 },
+            { width: 390, height: 844 },
+        ]) {
+            await page.setViewportSize(viewport);
+
+            const longName = page.getByText(longItemName, { exact: true });
+            const truncation = await longName.evaluate((element) => {
+                const style = getComputedStyle(element);
+                return {
+                    clientWidth: element.clientWidth,
+                    scrollWidth: element.scrollWidth,
+                    textOverflow: style.textOverflow,
+                    whiteSpace: style.whiteSpace,
+                };
+            });
+
+            expect(truncation.scrollWidth, `${viewport.width}px truncated name`).toBeGreaterThan(
+                truncation.clientWidth
+            );
+            expect(truncation.textOverflow).toBe('ellipsis');
+            expect(truncation.whiteSpace).toBe('nowrap');
+
+            const hasHorizontalOverflow = await page.evaluate(() => {
+                const root = document.scrollingElement ?? document.documentElement;
+                return root.scrollWidth > root.clientWidth;
+            });
+            expect(hasHorizontalOverflow, `${viewport.width}px horizontal overflow`).toBe(false);
+
+            if (viewport.width < 900) {
+                await expect(page.getByTestId('items-list').getByText('Type', { exact: true })).toBeHidden();
+                await expect(page.getByRole('link', { name: 'Open container Garage' })).toContainText(
+                    'Container • Workshop and storage area'
+                );
+            } else {
+                await expect(page.getByTestId('items-list').getByText('Type', { exact: true })).toBeVisible();
+            }
+
+            if (viewport.width === 390) {
+                const phoneRowBox = await page.getByTestId('inventory-row').first().boundingBox();
+                if (phoneRowBox === null) throw new Error('Phone inventory row is not visible');
+                expect(phoneRowBox.height).toBeGreaterThanOrEqual(64);
+
+                const sortBox = await page.getByRole('combobox', { name: 'Sort inventory' }).boundingBox();
+                if (sortBox === null) throw new Error('Phone sort control is not visible');
+                expect(sortBox.height).toBeGreaterThanOrEqual(44);
+            }
+        }
+    });
+});

--- a/tests/e2e/app/items-and-tags.spec.ts
+++ b/tests/e2e/app/items-and-tags.spec.ts
@@ -72,11 +72,16 @@ test.describe('Items view', () => {
 
         await reloadAndWait(page);
 
-        await expect(page.getByTestId('items-list').getByRole('link')).toHaveText([
-            'Box 2',
-            'Box 10',
-            'Cable 2',
-            'Cable 10',
+        const inventoryLinks = page.getByTestId('items-list').getByRole('link');
+        await expect(inventoryLinks).toHaveCount(4);
+        const sortedAccessibleNames = await inventoryLinks.evaluateAll((links) =>
+            links.map((link) => link.getAttribute('aria-label'))
+        );
+        expect(sortedAccessibleNames).toEqual([
+            'Open container Box 2',
+            'Open container Box 10',
+            'View item Cable 2',
+            'View item Cable 10',
         ]);
     });
 

--- a/tests/e2e/helpers/storybook-helpers.ts
+++ b/tests/e2e/helpers/storybook-helpers.ts
@@ -7,7 +7,7 @@ import type { Page } from '@playwright/test';
  * cd meteor-app && npm run storybook
  * ```
  */
-export const STORYBOOK_BASE_URL = 'http://localhost:6006';
+export const STORYBOOK_BASE_URL = process.env.PLAYWRIGHT_STORYBOOK_BASE_URL ?? 'http://localhost:6006';
 
 /**
  * Builds a Storybook story URL for isolated component testing.

--- a/tests/e2e/storybook/AllItemsView.spec.ts
+++ b/tests/e2e/storybook/AllItemsView.spec.ts
@@ -3,6 +3,75 @@ import { expect, test } from '@playwright/test';
 import { gotoStory } from '../helpers/storybook-helpers';
 
 test.describe('AllItemsView Component (Storybook)', () => {
+    test('covers loading, empty, short, and 100-plus inventory fixtures', async ({ page }) => {
+        await gotoStory(page, 'ui-allitemsview', 'loading-inventory');
+        await expect(page.getByTestId('inventory-count')).toContainText('Loading inventory…');
+        await expect(page.getByRole('status', { name: 'Loading inventory entries' })).toBeVisible();
+        await expect(page.getByRole('combobox', { name: 'Sort inventory' })).toBeDisabled();
+
+        await gotoStory(page, 'ui-allitemsview', 'empty-inventory');
+        await expect(page.getByTestId('inventory-count')).toContainText('0 entries');
+        await expect(page.getByText('No items at this level')).toBeVisible();
+
+        await gotoStory(page, 'ui-allitemsview', 'short-inventory');
+        await expect(page.getByTestId('inventory-count')).toContainText('3 entries');
+        await expect(page.getByTestId('inventory-count')).toContainText('1 container • 2 items');
+        await expect(page.getByText('Tools', { exact: true })).toBeVisible();
+        await page.getByRole('combobox', { name: 'Sort inventory' }).selectOption('name-desc');
+        const sortedAccessibleNames = await page
+            .getByTestId('items-list')
+            .getByRole('link')
+            .evaluateAll((links) => links.map((link) => link.getAttribute('aria-label')));
+        expect(sortedAccessibleNames).toEqual(['Open container Garage', 'View item Mountain Bike', 'View item Hammer']);
+
+        await gotoStory(page, 'ui-allitemsview', 'hundred-plus-inventory');
+        await expect(page.getByTestId('inventory-count')).toContainText('106 entries');
+        await expect(page.getByTestId('items-list').getByRole('link')).toHaveCount(106);
+    });
+
+    test('uses the responsive density model at 1440, 768, and 390px', async ({ page }) => {
+        const viewports = [
+            { width: 1440, height: 900, desktopColumns: true },
+            { width: 768, height: 1024, desktopColumns: false },
+            { width: 390, height: 844, desktopColumns: false },
+        ];
+
+        for (const viewport of viewports) {
+            await page.setViewportSize({ width: viewport.width, height: viewport.height });
+            await gotoStory(page, 'ui-allitemsview', 'hundred-plus-inventory');
+
+            const firstRow = page.getByTestId('inventory-row').first();
+            const longName = page.getByText(/A deliberately long inventory item name/);
+            const metrics = await longName.evaluate((element) => {
+                const style = getComputedStyle(element);
+                return {
+                    clientWidth: element.clientWidth,
+                    scrollWidth: element.scrollWidth,
+                    textOverflow: style.textOverflow,
+                    whiteSpace: style.whiteSpace,
+                };
+            });
+
+            expect(metrics.scrollWidth).toBeGreaterThan(metrics.clientWidth);
+            expect(metrics.textOverflow).toBe('ellipsis');
+            expect(metrics.whiteSpace).toBe('nowrap');
+            await expect(page.getByText('Type', { exact: true })).toBeVisible({ visible: viewport.desktopColumns });
+
+            const hasHorizontalOverflow = await page.evaluate(() => {
+                const root = document.scrollingElement ?? document.documentElement;
+                return root.scrollWidth > root.clientWidth;
+            });
+            expect(hasHorizontalOverflow, `${viewport.width}px horizontal overflow`).toBe(false);
+
+            if (viewport.width === 390) {
+                const rowBox = await firstRow.boundingBox();
+                if (rowBox === null) throw new Error('Phone inventory row is not visible');
+                expect(rowBox.height).toBeGreaterThanOrEqual(64);
+                await expect(firstRow).toContainText(/Container|Item/);
+            }
+        }
+    });
+
     test('keeps scrolling isolated to the items list in the app-shell regression story', async ({ page }) => {
         await gotoStory(page, 'ui-allitemsview', 'app-shell-scroll-regression');
 


### PR DESCRIPTION
## Summary

- Replace the sparse inventory list with a centered, bounded inventory sheet designed for scanning 100+ entries.
- Add total/container/item counts, explicit name/update sorting, container cues, descriptions, tag summaries, update dates, and deterministic ellipsis.
- Use a five-column desktop model at 900px+, condensed metadata from 600–899px, and simple 64px touch rows below 600px.
- Keep loading and empty context visible; add short and 106-entry Storybook fixtures plus an isolated real-app seed fixture.

## Design decision

The inventory row reserves one trailing 24px affordance column beside the semantic row link. This leaves room for the future bd-bv8.2.6 row-action concept without nesting interactive controls or exposing Milestone 3 actions now.

This PR does not redesign compound filters or mobile tag management.

## Verification

- `npm run format:check` — passed
- `npm run check:type` — passed
- `npm run check:code-style:lint` — passed
- `npm run test:scripts` — 13 passed
- `npm run build-storybook` — passed
- full Storybook Playwright — 38 passed, 3 skipped
- focused inventory Storybook Playwright — 3 passed
- focused inventory app Playwright (Chromium) — 3 passed
- focused inventory app Playwright (iPad + iPhone) — 6 passed
- app smoke regression — 11 passed
- full app Chromium diagnostic — 81 passed, 1 skipped, 4 failed; both actionable failures passed individually after fixes
- remaining two app failures are unrelated UMR import previews that exceed the existing 5s wait
- new `inventorySort` unit tests — 3 passed
- full Meteor unit diagnostic reached 223 passing with the unrelated UMR import exceeding its existing 2s timeout; the timeout can cascade into shared-state assertions on rerun

## Visual review

Before and after screenshots were captured and inspected at:

- 1440px: bounded five-column comparison view, visible count/sort, metadata, and truncation
- 768px: condensed one-line metadata with no horizontal overflow
- 390px: separate header actions, 64px rows, explicit 44px sort control, and predictable truncation

## Tracking

Beads: `bd-bv8.2.1` — Redesign inventory browsing for efficient scanning.
